### PR TITLE
Fix: Improve configuration, logging, and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,26 +56,52 @@ cp example.config.yaml config.yaml
 ### Edit the Configuration Variables
 
 Open the config.yaml in a text editor:
-```
-# Configuration
-OVERSEERR_BASEURL = "http://127.0.0.1:5055"  # Replace with your Overseerr base URL
-DRY_RUN = False  # Set to True to enable dry run mode
+```yaml
+# Overall log level for the script. Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL: "INFO"
 
-API_KEYS = {
-    "overseerr": "YOUR_OVERSEERR_API_KEY",
+# The URL of your Overseerr instance
+OVERSEERR_BASEURL: "http://127.0.0.1:5055" # Replace with your Overseerr base URL
 
-}
+# DRY_RUN mode
+# If true, the script will log actions it would take but not actually perform them.
+DRY_RUN: false
+
+# API Keys
+API_KEYS:
+  overseerr: "YOUR_OVERSEERR_API_KEY"
+  # Add other API keys if needed by future integrations
+
+# Server configuration for the webhook listener
+SERVER:
+  HOST: "0.0.0.0"  # Host to bind the server to (e.g., "0.0.0.0" for all interfaces)
+  PORT: 12210       # Port to listen on
+  THREADS: 5        # Number of threads for the server
+  CONNECTION_LIMIT: 200 # Maximum number of simultaneous connections
 
 # Notifiarr (Optional)
+# Configuration for sending notifications via Notifiarr
 NOTIFIARR:
   API_KEY: "YOUR_NOTIFIARR_KEY_HERE"
-  CHANNEL: 123456789012345678  
-  SOURCE: "OverFiltrr"
+  CHANNEL: 123456789012345678 # Your Notifiarr Channel ID
+  SOURCE: "OverFiltrr" # Source label for notifications
+  TIMEOUT: 10 # Timeout in seconds for Notifiarr API requests
 ```
 
-- OVERSEERR_BASEURL: Replace with the base URL of your Overseerr instance (e.g., http://your-overseerr-domain.com).
-- DRY_RUN: Set to True to test without making actual changes.
-- API_KEYS: Replace with your actual API keys.
+- `LOG_LEVEL`: Defines the verbosity of logs. Options: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+- `OVERSEERR_BASEURL`: The base URL of your Overseerr instance (e.g., `http://your-overseerr-domain.com`).
+- `DRY_RUN`: If `true`, the script logs actions without making changes. Default: `false`.
+- `API_KEYS`: Contains API keys for services. Currently, only `overseerr` is used.
+- `SERVER`:
+    - `HOST`: IP address for the server to bind to. Default: `"0.0.0.0"`.
+    - `PORT`: Port for the server to listen on. Default: `12210`.
+    - `THREADS`: Number of worker threads for the server. Default: `5`.
+    - `CONNECTION_LIMIT`: Maximum number of simultaneous connections. Default: `200`.
+- `NOTIFIARR` (Optional):
+    - `API_KEY`: Your Notifiarr API key.
+    - `CHANNEL`: The Notifiarr channel ID for notifications.
+    - `SOURCE`: A source label for notifications (e.g., "OverFiltrr"). Default: `"OverFiltrr"`.
+    - `TIMEOUT`: Timeout in seconds for Notifiarr API requests. Default: `10`.
 
 ### Configure Categories
 
@@ -89,34 +115,32 @@ Customise the **TV_CATEGORIES** and **MOVIE_CATEGORIES** to define how media sho
     - **Category Name** :
       - **`filters`** : Filters for genres, keywords, and excluded ratings.
       - **`apply`** :
-        - **`root_folder`** : The destination root folder.
-        - **`default_profile_id`** : Default quality profile ID.
-        - **`sonarr_id`** : The Sonarr server ID for the category.
-        - **`app_name`** : A descriptive name for logging purposes.
-        - **`quality_profile_rules`** : Rules for dynamic quality profile selection.
-      - **`weight`** : Priority weight for this category.
+        - **`root_folder`** : The destination root folder (Required).
+        - **`default_profile_id`** : Fallback quality profile ID. This is **required** if `quality_profile_rules` are not defined, are empty, or if no rules match.
+        - **`sonarr_id`** : The Sonarr server ID (as configured in Overseerr) for this category (Required).
+        - **`app_name`** : A descriptive name for logging and notification purposes (Optional).
+      - **`quality_profile_rules`** (Optional): Rules for dynamic quality profile selection. If omitted or empty, `default_profile_id` must be set.
+      - **`weight`** : Priority weight for this category (Required). Higher numbers mean higher priority.
 
 Example:
-```
+```yaml
 TV_CATEGORIES:
-  Anime:
-    filters:
+  Anime: # Name of the category
+    filters: # Optional: criteria for media to fall into this category
       keywords:
         - "anime"
-      excluded_ratings: # (Optional)
+      excluded_ratings: # Optional: list of age ratings to exclude from this category
         - "NC-17"
         - "TV-MA"
         - "R"
-
     apply:
       root_folder: "/mnt/media/sonarr/Anime"
-      default_profile_id: 10 # (Optional)
+      # default_profile_id is required here if quality_profile_rules below don't match or are absent
+      default_profile_id: 10
       sonarr_id: 3
-      app_name: "Anime TV" # (Optional)
-    
-    weight: 100
-
-    quality_profile_rules: # (Optional)
+      app_name: "Anime TV"
+    weight: 100 # Higher weight means this category is checked first
+    quality_profile_rules: # Optional: rules to dynamically select a quality profile
       - priority: 1
         condition:
           original_language:
@@ -137,19 +161,18 @@ TV_CATEGORIES:
     - **Category Name** :
       - **`filters`** : Filters for genres, keywords, and excluded ratings.
       - **`apply`** :
-        - **`root_folder`** : The destination root folder.
-        - **`default_profile_id`** : Default quality profile ID.
-        - **`radarr_id`** : The Radarr server ID for the category.
-        - **`app_name`** : A descriptive name for logging purposes.
-        - **`quality_profile_rules`** : Rules for dynamic quality profile selection.
-      - **`weight`** : Priority weight for this category.
+        - **`root_folder`** : The destination root folder (Required).
+        - **`default_profile_id`** : Fallback quality profile ID. This is **required** if `quality_profile_rules` are not defined, are empty, or if no rules match.
+        - **`radarr_id`** : The Radarr server ID (as configured in Overseerr) for this category (Required).
+        - **`app_name`** : A descriptive name for logging and notification purposes (Optional).
+      - **`quality_profile_rules`** (Optional): Rules for dynamic quality profile selection. If omitted or empty, `default_profile_id` must be set.
+      - **`weight`** : Priority weight for this category (Required). Higher numbers mean higher priority.
 
 Example:
-```
+```yaml
 MOVIE_CATEGORIES:
-
-  KidMovies:
-    filters:
+  KidMovies: # Name of the category
+    filters: # Optional: criteria for media to fall into this category
       genres:
         - "Animation"
         - "Family"
@@ -157,18 +180,18 @@ MOVIE_CATEGORIES:
         - "kids"
         - "child"
         - "animated"
-      excluded_ratings:
+      excluded_ratings: # Optional: list of age ratings to exclude
         - "R"
         - "NC-17"
         - "TV-MA"
     apply:
       root_folder: "/mnt/media/radarr/KidMovies"
+      # default_profile_id is required here if quality_profile_rules below don't match or are absent
       default_profile_id: 15
       radarr_id: 1
       app_name: "Kid Movies"
-    weight: 80
-
-    quality_profile_rules:
+    weight: 80 # Higher weight means this category is checked first
+    quality_profile_rules: # Optional: rules to dynamically select a quality profile
       - priority: 1
         condition:
           providers:
@@ -189,13 +212,18 @@ Each rule is defined as an object with the following keys:
 
 - **`condition`** :
   - Specifies the criteria for applying the rule. Conditions support logical operators and can include multiple attributes.
-  - Supported attributes:
-    - **`release_year`**: Matches the media's release year.
-    - **`original_language`**: Matches the media's original language.
-    - **`streaming_service`**: Matches the media's streaming provider.
-    - **`network`** *(TV only)*: Matches the media's originating network.
+  - Supported attributes for conditions:
+    - `release_year`: Media's release year.
+    - `original_language`: Media's original language (e.g., "en", "ja").
+    - `providers`: List of streaming providers for the media (e.g., "Netflix", "Hulu").
+    - `production_companies`: List of production companies.
+    - `networks` (TV only): List of TV networks.
+    - `status`: Media's status (e.g., "Released", "Ended", "Returning Series").
+    - `genres`: List of genres associated with the media.
+    - `keywords`: List of keywords associated with the media.
   - Supported operators:
-    - `<`, `<=`, `>`, `>=`, `==`, `!=`, `in`, `not in`
+    - `<`, `<=`, `>`, `>=`, `==`, `!=` (for single value attributes like `release_year`, `original_language`, `status`)
+    - `in`, `not in` (for list attributes like `providers`, `genres`, `keywords`, `networks`, and can also be used with single value attributes if the target in the config is a list)
   - Example:
     ```yaml
     condition:
@@ -230,9 +258,11 @@ To enable Overseerr to communicate with OverFiltrr:
 
 - Navigate to Overseerr Settings: Go to Settings > Notifications > Webhooks.
 - Configure the Webhook:
-  - Webhook URL: http://your-overfiltrr-domain-or-ip:12210/settings/notifications/webhook
-  - Payload:
-  - ```{
+  - Webhook URL: `http://<your_overfiltrr_host_or_ip>:<port>/webhook` (e.g., `http://localhost:12210/webhook` if running locally on the default port).
+  - Notification Type: Ensure **Request Pending Approval** is checked. Other types can be enabled but OverFiltrr currently only processes `MEDIA_PENDING` which is triggered by this event.
+  - JSON Payload:
+  ```json
+  {
     "notification_type": "{{notification_type}}",
     "event": "{{event}}",
     "subject": "{{subject}}",
@@ -265,14 +295,11 @@ To enable Overseerr to communicate with OverFiltrr:
         "commentedBy_username": "{{commentedBy_username}}",
         "commentedBy_avatar": "{{commentedBy_avatar}}"
     },
-    "{{extra}}": []}
-    ```
-  - Enable the **Request Pending Approval** notification type.
-  - You must turn off Auto-Approve for users
-  - Save: Click Save to add the webhook.
- 
-> [!IMPORTANT]
-> I repeat you must turn off Auto-Approve for users
+    "{{extra}}": []
+  }
+  ```
+  - **Crucially, you must turn off Auto-Approve for users within Overseerr's user settings.** OverFiltrr handles the approval logic. If Overseerr auto-approves, OverFiltrr might not be able to apply its detailed category and quality profile logic correctly.
+  - Save: Click "Save Changes" to add the webhook.
 
 
 ### Usage

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,18 +1,31 @@
+# Overall log level for the script. Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL: "INFO"
+
 # The URL of your Overseerr instance
 OVERSEERR_BASEURL: "http://127.0.0.1:5055"
 
 # DRY_RUN mode
+# If true, the script will log actions it would take but not actually perform them.
 DRY_RUN: false
 
 # API Keys 
 API_KEYS:
   overseerr: "YOUR_OVERSEERR_API_KEY_HERE"
 
+# Server configuration for the webhook listener
+SERVER:
+  HOST: "0.0.0.0"  # Host to bind the server to
+  PORT: 12210       # Port to listen on
+  THREADS: 5        # Number of threads for the server
+  CONNECTION_LIMIT: 200 # Maximum number of simultaneous connections
+
 # Notifiarr (Optional)
+# Configuration for sending notifications via Notifiarr
 NOTIFIARR:
   API_KEY: "YOUR_NOTIFIARR_KEY_HERE"
   CHANNEL: 123456789012345678  
   SOURCE: "OverFiltrr"
+  TIMEOUT: 10 # Timeout in seconds for Notifiarr API requests
 
 # TV_CATEGORIES
 #   - Defines how TV requests (Sonarr) are categorized.
@@ -34,8 +47,8 @@ TV_CATEGORIES:
     apply:
       # Where to store the TV show if it matches
       root_folder: "/mnt/media/sonarr/Anime"
-      # Fallback quality profile for the category if no rule matches
-      default_profile_id: 10 # (Optional)
+      # Fallback quality profile. Required if 'quality_profile_rules' are missing, empty, or no rules match.
+      default_profile_id: 10
       # The 'sonarr_id' is the ID of your Sonarr server in Overseerr
       sonarr_id: 3
       # Just a friendly label for logs/notifications
@@ -72,6 +85,7 @@ TV_CATEGORIES:
 
     apply:
       root_folder: "/mnt/media/sonarr/English"
+      # Fallback quality profile. Required if 'quality_profile_rules' are missing, empty, or no rules match.
       default_profile_id: 21
       sonarr_id: 2
       app_name: "English TV"
@@ -113,6 +127,7 @@ TV_CATEGORIES:
       # This category only gets chosen if 'Foreign' or 'foreign' is found
     apply:
       root_folder: "/mnt/media/sonarr/Foreign"
+      # Fallback quality profile. Required if 'quality_profile_rules' are missing, empty, or no rules match.
       default_profile_id: 22
       sonarr_id: 4
       app_name: "Foreign TV"
@@ -143,6 +158,7 @@ MOVIE_CATEGORIES:
         - "TV-MA"
     apply:
       root_folder: "/mnt/media/radarr/KidMovies"
+      # Fallback quality profile. Required if 'quality_profile_rules' are missing, empty, or no rules match.
       default_profile_id: 15
       radarr_id: 1
       app_name: "Kid Movies"
@@ -174,6 +190,7 @@ MOVIE_CATEGORIES:
         - "NC-17"
     apply:
       root_folder: "/mnt/media/radarr/Action"
+      # Fallback quality profile. Required if 'quality_profile_rules' are missing, empty, or no rules match.
       default_profile_id: 20
       radarr_id: 2
       app_name: "Action Movies"
@@ -200,6 +217,7 @@ MOVIE_CATEGORIES:
     # No filters means it can catch everything that’s not matched by other categories
     apply:
       root_folder: "/mnt/media/radarr/Everything"
+      # Fallback quality profile. Required if 'quality_profile_rules' are missing, empty, or no rules match.
       default_profile_id: 10
       radarr_id: 3
       app_name: "General Movies"

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,0 +1,52 @@
+OVERSEERR_BASEURL: "http://localhost:5055"
+DRY_RUN: True
+API_KEYS:
+  overseerr: "your_overseerr_api_key"
+  # other app API keys
+
+TV_CATEGORIES:
+  default: "standard_tv"
+  anime_tv:
+    weight: 1
+    # Missing quality_profile_rules and default_profile_id - this should cause an error
+    apply:
+      root_folder: "/tv/Anime/"
+      sonarr_id: 1
+      app_name: "Sonarr Anime"
+    filters:
+      genres: ["Animation", "Anime"]
+  standard_tv:
+    weight: 0
+    quality_profile_rules:
+      - priority: 1
+        profile_id: 1
+        condition:
+          release_year: { ">=": 2020 }
+    apply:
+      root_folder: "/tv/Standard/"
+      sonarr_id: 2
+      app_name: "Sonarr Standard"
+      default_profile_id: 1 # Present here, but quality_profile_rules is also present
+
+MOVIE_CATEGORIES:
+  default: "standard_movies"
+  action_movies:
+    weight: 1
+    quality_profile_rules: [] # Empty quality_profile_rules, missing default_profile_id - this should also cause an error
+    apply:
+      root_folder: "/movies/Action/"
+      radarr_id: 1
+      app_name: "Radarr Action"
+    filters:
+      genres: ["Action"]
+  standard_movies:
+    weight: 0
+    apply:
+      root_folder: "/movies/Standard/"
+      radarr_id: 2
+      app_name: "Radarr Standard"
+      default_profile_id: 2 # default_profile_id is present, quality_profile_rules is missing (None) - this is okay
+NOTIFIARR:
+  API_KEY: "your_notifiarr_api_key"
+  CHANNEL: "your_notifiarr_channel_id"
+  SOURCE: "OverFiltrr Test"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the `tests` directory as a package.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,289 @@
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+import sys
+import os
+import yaml
+import importlib
+
+# --- Start of Pre-Import Patching ---
+# Goal: Allow 'import overfiltrr' to succeed by ensuring its initial
+# config loading logic encounters mocked file operations and sys.exit.
+
+MINIMAL_MOCK_CONFIG_FOR_IMPORT = {
+    'OVERSEERR_BASEURL': 'http://mock.com', 'DRY_RUN': True,
+    'API_KEYS': {'overseerr': 'mock_key'},
+    'LOG_LEVEL': 'DEBUG',
+    'TV_CATEGORIES': {'default': 'd', 'd':{'weight':0,'apply':{'root_folder':'/','sonarr_id':1,'default_profile_id':1}}},
+    'MOVIE_CATEGORIES': {'default': 'd', 'd':{'weight':0,'apply':{'root_folder':'/','radarr_id':1,'default_profile_id':1}}},
+    'SERVER': {'HOST': '0.0.0.0', 'PORT': 12210, 'THREADS': 1, 'CONNECTION_LIMIT': 10},
+    'NOTIFIARR': {'API_KEY': 'mock_notifiarr', 'CHANNEL': '1', 'SOURCE': 'mock_source', 'TIMEOUT': 5}
+}
+
+# 1. Patch builtins.open
+mock_config_content = yaml.dump(MINIMAL_MOCK_CONFIG_FOR_IMPORT)
+# Make sure this patch is applied before overfiltrr.py's load_config is ever called.
+# This will affect the open() call within load_config in overfiltrr.py.
+patch_builtin_open = patch('builtins.open', mock_open(read_data=mock_config_content))
+patch_builtin_open.start()
+
+# 2. Patch yaml.safe_load
+# This will affect the yaml.safe_load() call within load_config in overfiltrr.py.
+patch_yaml_safe_load = patch('yaml.safe_load', return_value=MINIMAL_MOCK_CONFIG_FOR_IMPORT)
+patch_yaml_safe_load.start()
+
+# 3. Patch sys.exit
+# This will prevent sys.exit() calls within load_config from stopping tests.
+patch_sys_exit = patch('sys.exit', MagicMock())
+patch_sys_exit.start()
+
+# 4. Patch logging.config.dictConfig (used by setup_logging called after load_config in overfiltrr.py)
+patch_logging_dict_config = patch('logging.config.dictConfig', MagicMock())
+patch_logging_dict_config.start()
+# --- End of Pre-Import Patching ---
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# When overfiltrr is imported, its load_config function will use the mocked 'open' and 'yaml.safe_load'.
+# The call to setup_logging will use the mocked 'logging.config.dictConfig'.
+# Any sys.exit call will hit the MagicMock.
+import overfiltrr
+
+# Stop the global pre-import patches after the import of overfiltrr.
+# This is crucial so that these broad patches don't interfere with
+# more specific patches used within individual test methods.
+patch_builtin_open.stop()
+patch_yaml_safe_load.stop()
+patch_sys_exit.stop()
+patch_logging_dict_config.stop()
+
+
+class TestConfigValidation(unittest.TestCase):
+
+    # --- Tests for validate_categories ---
+    def test_validate_categories_valid_config(self):
+        """Test validate_categories with a minimal valid configuration."""
+        valid_tv_categories = {
+            "default": "standard_tv",
+            "anime_tv": {
+                "weight": 1,
+                "apply": {
+                    "root_folder": "/tv/Anime/",
+                    "sonarr_id": 1,
+                    "default_profile_id": 5
+                },
+                "filters": {"genres": ["Animation"]},
+            },
+            "standard_tv": {
+                "weight": 0,
+                "quality_profile_rules": [
+                    {"priority": 1, "profile_id": 1, "condition": {"release_year": {">=": 2020}}}
+                ],
+                "apply": {
+                    "root_folder": "/tv/Standard/",
+                    "sonarr_id": 2,
+                    "default_profile_id": 6
+                }
+            }
+        }
+        self.assertTrue(overfiltrr.validate_categories(valid_tv_categories, 'tv'))
+
+        valid_movie_categories = {
+            "default": "standard_movies",
+            "action_movies": {
+                "weight": 1,
+                "quality_profile_rules": [
+                     {"priority": 1, "profile_id": 1, "condition": {"genres": {"in": ["Action"]}}}
+                ],
+                "apply": {
+                    "root_folder": "/movies/Action/",
+                    "radarr_id": 1,
+                    "default_profile_id": 2
+                }
+            },
+            "standard_movies": {
+                "weight": 0,
+                "apply": {
+                    "root_folder": "/movies/Standard/",
+                    "radarr_id": 2,
+                    "default_profile_id": 3
+                }
+            }
+        }
+        self.assertTrue(overfiltrr.validate_categories(valid_movie_categories, 'movie'))
+
+
+    @patch('logging.error')
+    def test_validate_categories_missing_default_id_no_rules(self, mock_logging_error):
+        """Test missing default_profile_id when quality_profile_rules are absent."""
+        categories = {
+            "default": "broken_tv",
+            "broken_tv": {
+                "weight": 1,
+                "apply": {
+                    "root_folder": "/tv/Broken/",
+                    "sonarr_id": 1
+                }
+            }
+        }
+        self.assertFalse(overfiltrr.validate_categories(categories, 'tv'))
+        mock_logging_error.assert_any_call(
+            "Category 'broken_tv' must have 'default_profile_id' in 'apply' when 'quality_profile_rules' are missing or empty."
+        )
+
+    @patch('logging.error')
+    def test_validate_categories_missing_default_id_empty_rules(self, mock_logging_error):
+        """Test missing default_profile_id when quality_profile_rules is an empty list."""
+        categories = {
+            "default": "broken_tv",
+            "broken_tv": {
+                "weight": 1,
+                "quality_profile_rules": [],
+                "apply": {
+                    "root_folder": "/tv/Broken/",
+                    "sonarr_id": 1
+                }
+            }
+        }
+        self.assertFalse(overfiltrr.validate_categories(categories, 'tv'))
+        mock_logging_error.assert_any_call(
+            "Category 'broken_tv' must have 'default_profile_id' in 'apply' when 'quality_profile_rules' are missing or empty."
+        )
+
+    def test_validate_categories_present_default_id_with_rules(self):
+        """Test valid when default_profile_id is present WITH quality_profile_rules."""
+        categories = {
+            "default": "valid_tv",
+            "valid_tv": {
+                "weight": 1,
+                "quality_profile_rules": [
+                    {"priority": 1, "profile_id": 1, "condition": {"release_year": {">=": 2020}}}
+                ],
+                "apply": {
+                    "root_folder": "/tv/Valid/",
+                    "sonarr_id": 1,
+                    "default_profile_id": 5
+                }
+            }
+        }
+        self.assertTrue(overfiltrr.validate_categories(categories, 'tv'))
+
+    def test_validate_categories_present_default_id_no_rules(self):
+        """Test valid when default_profile_id is present and no quality_profile_rules."""
+        categories = {
+            "default": "valid_tv",
+            "valid_tv": {
+                "weight": 1,
+                "apply": {
+                    "root_folder": "/tv/Valid/",
+                    "sonarr_id": 1,
+                    "default_profile_id": 5
+                }
+            }
+        }
+        self.assertTrue(overfiltrr.validate_categories(categories, 'tv'))
+
+
+    @patch('sys.exit')
+    @patch('logging.critical')
+    # We need to ensure that validate_configuration uses the categories we provide,
+    # not the ones loaded by the initial (mocked) import of overfiltrr.
+    # So, we patch the global TV_CATEGORIES and MOVIE_CATEGORIES in overfiltrr for this test.
+    @patch('overfiltrr.TV_CATEGORIES', new_callable=dict)
+    @patch('overfiltrr.MOVIE_CATEGORIES', new_callable=dict)
+    # No need to mock load_config or setup_logging if we are directly setting the category globals
+    # and testing validate_configuration's logic based on those.
+    def test_validate_configuration_exits_on_invalid_category(self, mock_movie_cat, mock_tv_cat, mock_log_critical, mock_sys_exit):
+        """Test that validate_configuration calls sys.exit for invalid categories."""
+        invalid_tv_config = {
+            "default": "broken_tv",
+            "broken_tv": {"weight": 1, "apply": {"root_folder": "/tv/Broken/", "sonarr_id": 1}} # Invalid
+        }
+        valid_movie_config = {
+             "default": "std_mov",
+             "std_mov": {"weight":0, "apply": {"root_folder":"/", "radarr_id":1, "default_profile_id":1}}
+        }
+
+        # Update the patched global dictionaries directly
+        mock_tv_cat.update(invalid_tv_config)
+        mock_movie_cat.update(valid_movie_config)
+
+        overfiltrr.validate_configuration()
+
+        mock_log_critical.assert_called_with("Configuration validation failed. Please fix the errors and restart the script.")
+        mock_sys_exit.assert_called_with(1)
+
+
+    # --- Tests for Notifiarr Timeout (via reloading module with patched file I/O) ---
+    # These tests will reload the overfiltrr module. The pre-import patches are stopped,
+    # so each of these tests needs to set up its own environment for the reload.
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    @patch('logging.config.dictConfig', MagicMock()) # Mock underlying logging setup
+    @patch('overfiltrr.setup_logging', MagicMock()) # Mock the direct call to setup_logging
+    def test_notifiarr_timeout_specified(self, mock_yaml_safe_load, mock_file_open):
+        """Test Notifiarr timeout when specified in config by reloading module."""
+        config_dict = {
+            'OVERSEERR_BASEURL': 'http://test.com', 'DRY_RUN': False, 'API_KEYS': {'overseerr': 'key'},
+            'LOG_LEVEL': 'INFO',
+            'TV_CATEGORIES': {'default': 'test', 'test': {'weight': 1, 'apply': {'root_folder': '/', 'sonarr_id': 1, 'default_profile_id': 1}}},
+            'MOVIE_CATEGORIES': {'default': 'test', 'test': {'weight': 1, 'apply': {'root_folder': '/', 'radarr_id': 1, 'default_profile_id': 1}}},
+            'NOTIFIARR': {'API_KEY': 'key', 'CHANNEL': 'chan', 'SOURCE': 'src', 'TIMEOUT': 15},
+            'SERVER': {}
+        }
+        mock_yaml_safe_load.return_value = config_dict
+        # Configure mock_file_open if load_config actually reads the file content in the test
+        # For these tests, yaml.safe_load is directly returning the dict, so read_data isn't strictly needed for it.
+        # However, good practice if load_config was more complex:
+        mock_file_open.return_value.read.return_value = yaml.dump(config_dict)
+
+
+        importlib.reload(overfiltrr)
+
+        self.assertEqual(overfiltrr.NOTIFIARR_TIMEOUT, 15)
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    @patch('logging.config.dictConfig', MagicMock())
+    @patch('overfiltrr.setup_logging', MagicMock())
+    def test_notifiarr_timeout_not_specified(self, mock_yaml_safe_load, mock_file_open):
+        """Test Notifiarr timeout defaults to 10 when not specified."""
+        config_dict = {
+            'OVERSEERR_BASEURL': 'http://test.com', 'DRY_RUN': False, 'API_KEYS': {'overseerr': 'key'},
+            'LOG_LEVEL': 'INFO',
+            'TV_CATEGORIES': {'default': 'test', 'test': {'weight': 1, 'apply': {'root_folder': '/', 'sonarr_id': 1, 'default_profile_id': 1}}},
+            'MOVIE_CATEGORIES': {'default': 'test', 'test': {'weight': 1, 'apply': {'root_folder': '/', 'radarr_id': 1, 'default_profile_id': 1}}},
+            'NOTIFIARR': {'API_KEY': 'key', 'CHANNEL': 'chan', 'SOURCE': 'src'},
+            'SERVER': {}
+        }
+        mock_yaml_safe_load.return_value = config_dict
+        mock_file_open.return_value.read.return_value = yaml.dump(config_dict)
+
+        importlib.reload(overfiltrr)
+
+        self.assertEqual(overfiltrr.NOTIFIARR_TIMEOUT, 10)
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    @patch('logging.config.dictConfig', MagicMock())
+    @patch('overfiltrr.setup_logging', MagicMock())
+    def test_notifiarr_timeout_section_missing(self, mock_yaml_safe_load, mock_file_open):
+        """Test Notifiarr timeout defaults to 10 when NOTIFIARR section is missing."""
+        config_dict = {
+            'OVERSEERR_BASEURL': 'http://test.com', 'DRY_RUN': False, 'API_KEYS': {'overseerr': 'key'},
+            'LOG_LEVEL': 'INFO',
+            'TV_CATEGORIES': {'default': 'test', 'test': {'weight': 1, 'apply': {'root_folder': '/', 'sonarr_id': 1, 'default_profile_id': 1}}},
+            'MOVIE_CATEGORIES': {'default': 'test', 'test': {'weight': 1, 'apply': {'root_folder': '/', 'radarr_id': 1, 'default_profile_id': 1}}},
+            'SERVER': {}
+        }
+        mock_yaml_safe_load.return_value = config_dict
+        mock_file_open.return_value.read.return_value = yaml.dump(config_dict)
+
+        importlib.reload(overfiltrr)
+
+        self.assertEqual(overfiltrr.NOTIFIARR_TIMEOUT, 10)
+        self.assertIsNone(overfiltrr.NOTIFIARR_APIKEY)
+        self.assertIsNone(overfiltrr.NOTIFIARR_CHANNEL)
+        self.assertIsNone(overfiltrr.NOTIFIARR_SOURCE)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces several improvements to the OverFiltrr script:

- **Configuration Validation:**
  - `validate_categories` now ensures that `default_profile_id` is present in a category's `apply` section if `quality_profile_rules` are missing or empty for that category. The script will exit if this condition is not met.

- **Configurable Notifiarr Timeout:**
  - The Notifiarr API request timeout is now configurable via the `NOTIFIARR.TIMEOUT` option in `config.yaml` (defaults to 10 seconds).

- **Configuration-Driven Settings:**
  - `LOG_LEVEL` is now set via `config.yaml`.
  - Server parameters (host, port, threads, connection_limit) are now configurable via a `SERVER` section in `config.yaml`.

- **Improved Error Logging:**
  - Enhanced error logging in `process_request` for Overseerr API calls, including status codes and response text.
  - Added specific error logging if a `profile_id` cannot be determined for a media request.

- **Documentation Updates:**
  - `README.md` and `example.config.yaml` have been updated to reflect all new configuration options and validation logic.
  - Clarified requirements for `default_profile_id`.
  - Expanded documentation for quality profile rule attributes.

- **Unit Tests:**
  - Added a new test suite (`tests/test_config.py`) using the `unittest` module.
  - Tests cover the new configuration validation logic (especially for `default_profile_id` and `quality_profile_rules`) and the Notifiarr timeout configuration.
  - Implemented a pre-import patching strategy to allow testing of module-level configurations.
  - All new tests pass.

These changes enhance the script's robustness, configurability, and maintainability.