### PR TITLE
Add command-line log overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,12 @@ Start the OverFiltrr webhook server by running the script:
 python overfiltrr.py
 ```
 
+You can override the log level and log file location via command line:
+
+```
+python overfiltrr.py --log-level DEBUG --log-file /tmp/overfiltrr.log
+```
+
 The server will start and listen for webhook notifications from Overseerr on port 12210 by default.
 
 ### Configuring Overseerr Webhook

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,63 @@
+import importlib
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import overfiltrr
+
+
+class TestCLIArgs(unittest.TestCase):
+    def test_parse_cli_args_defaults(self):
+        args = overfiltrr.parse_cli_args([])
+        self.assertIsNone(args.log_level)
+        self.assertIsNone(args.log_file)
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("yaml.safe_load")
+    @patch("logging.config.dictConfig", MagicMock())
+    @patch("overfiltrr.serve", MagicMock())
+    def test_main_cli_overrides(self, mock_yaml_safe_load, mock_file_open):
+        config_dict = {
+            "OVERSEERR_BASEURL": "http://test.com",
+            "DRY_RUN": False,
+            "API_KEYS": {"overseerr": "key"},
+            "TV_CATEGORIES": {
+                "default": "test",
+                "test": {
+                    "weight": 1,
+                    "apply": {
+                        "root_folder": "/",
+                        "sonarr_id": 1,
+                        "default_profile_id": 1,
+                    },
+                },
+            },
+            "MOVIE_CATEGORIES": {
+                "default": "test",
+                "test": {
+                    "weight": 1,
+                    "apply": {
+                        "root_folder": "/",
+                        "radarr_id": 1,
+                        "default_profile_id": 1,
+                    },
+                },
+            },
+            "SERVER": {},
+        }
+        mock_yaml_safe_load.return_value = config_dict
+        mock_file_open.return_value.read.return_value = ""
+
+        importlib.reload(overfiltrr)
+        overfiltrr.main(["--log-level", "DEBUG", "--log-file", "custom.log"])
+
+        self.assertEqual(overfiltrr.LOGGING_CONFIG["root"]["level"], "DEBUG")
+        self.assertEqual(
+            overfiltrr.LOGGING_CONFIG["handlers"]["file"]["filename"], "custom.log"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow overriding log level and file via CLI arguments
- merge CLI options with YAML settings in `main`
- document the new options in the README
- test the new argument parsing

## Testing
- `pip install Flask==2.3.2 waitress==2.1.2 requests==2.31.0 rapidfuzz==3.1.1 rich==13.7.1`
- `pip install PyYAML==6.0.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845218ac778832f87fd3c86c75948c2