### PR TITLE
feat(cli): add list-ids command to print Radarr/Sonarr IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ Generate a secure webhook token (prints to stdout):
 python overfiltrr.py --gen-webhook-token [--size 32]
 ```
 
+List Radarr/Sonarr server IDs from Overseerr settings:
+
+```
+# List both Radarr and Sonarr
+python overfiltrr.py list-ids
+
+# Or target a specific service
+python overfiltrr.py list-ids radarr
+python overfiltrr.py --list-ids --svc sonarr
+```
+
 Health check:
 
 - `GET /health` → `{ "ok": true }`


### PR DESCRIPTION
Summary
- Adds a built‑in CLI to print Radarr/Sonarr server IDs from Overseerr settings.
- Mirrors the output of the existing bash+jq script (header + "id<TAB>name").

Usage
- List both: `python overfiltrr.py list-ids`
- Only Radarr: `python overfiltrr.py list-ids radarr`
- Only Sonarr: `python overfiltrr.py --list-ids --svc sonarr` (alias: `--service`)

Implementation
- Reads `OVERSEERR_BASEURL` and `API_KEYS.overseerr` from `config.yaml`.
- Calls `/api/v1/settings/{radarr|sonarr}` and prints each entry’s `id` and `name` (or `hostname` fallback).
- Handles missing config gracefully; falls back to raw JSON if the response shape differs.

Docs
- README updated with examples.
