### PR TITLE
Add Rich card logging with live steps, scoring table, and async NDJSON logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ MANIFEST
 *.manifest
 *.spec
 
-# Installer logs
+# Installer artifacts
 pip-log.txt
 pip-delete-this-directory.txt
 
@@ -56,7 +56,6 @@ cover/
 *.pot
 
 # Django stuff:
-*.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
@@ -70,6 +69,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/
 
 # PyBuilder
 .pybuilder/
@@ -162,5 +162,4 @@ cython_debug/
 #.idea/
  
 # OverFiltrr local artifacts
-logs/
 config.yaml

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Optional Notifiarr settings:
 Notes:
 
 - Server settings are configurable via `SERVER` in `config.yaml` (host, port, threads, connection limit). Defaults: `0.0.0.0:12210`, threads `15`, connection limit `500`.
-- Console log level can be set via environment variable `LOG_LEVEL` (e.g., `DEBUG`, `INFO`).
-- A JSON log file is written to `logs/script.log`.
 
 Optional webhook security:
 
@@ -172,13 +170,30 @@ MOVIE_CATEGORIES:
 
 ## DRY RUN
 
-Set `DRY_RUN: true` in `config.yaml` to log all decisions without updating or approving requests in Overseerr.
+Set `DRY_RUN: true` in `config.yaml` to simulate decisions without updating or approving requests in Overseerr.
 
-## Logs
+## Logging
 
-- Console logs have readable colored output.
-- File logs are JSON: `logs/script.log`.
-- Set `LOG_LEVEL` env var to control verbosity (e.g., `LOG_LEVEL=DEBUG`).
+- Console: OverFiltrr renders a single Rich-styled card per webhook with live step updates (falls back to clean plain text if Rich is not installed). It shows badges, step timings, and the final decision banner.
+- File: Structured NDJSON logs are written asynchronously to `logs/overfiltrr.log` (rotates at midnight, keeps 7 by default).
+
+Configure via `LOGGING` in `config.yaml` (all optional — sensible defaults apply):
+
+```
+LOGGING:
+  LEVEL: INFO
+  CONSOLE:
+    enabled: true
+    ascii: false
+  FILE:
+    enabled: true
+    path: logs/overfiltrr.log
+    rotate:
+      when: midnight
+      backup_count: 7
+```
+
+Note: If `python-json-logger` or `orjson` are available, they will be used automatically. Otherwise OverFiltrr uses a built-in NDJSON formatter.
 
 ## Notes
 

--- a/RELEASE_NOTES_v1.1.0.md
+++ b/RELEASE_NOTES_v1.1.0.md
@@ -7,7 +7,7 @@ Highlights
 - CLI helper: `python overfiltrr.py --gen-webhook-token [--size N]` prints a secure random token for use with `WEBHOOK.TOKEN`.
 - Config & reliability: Added `SERVER` settings (host/port/threads/connection limit) and `NOTIFIARR.TIMEOUT`; docs and example config updated.
 - Overseerr integration: Consolidated client logic; improved request processing and keyword handling.
-- Housekeeping: Removed unused modules/tests; trimmed requirements; logging/docs polish.
+- Housekeeping: Removed unused modules/tests; trimmed requirements; docs polish.
 
 Upgrade Notes
 
@@ -23,4 +23,3 @@ Selected Changes Since v1.0
 - Handle list keywords (f0c0247)
 - Add Overseerr API client and use in process_request (5a99446)
 - Various documentation and quality improvements
-

--- a/RELEASE_NOTES_v1.3.0.md
+++ b/RELEASE_NOTES_v1.3.0.md
@@ -1,9 +1,9 @@
-# v1.3.0 – Refactor: argparse CLI, early logging, safe JSON logs, runtime init
+# v1.3.0 – Refactor: argparse CLI, runtime init
 
 Highlights
 
 - Refactor to a single argparse-powered CLI in `overfiltrr.py`.
-- Early logging initialization with colored console output and safe JSON file logs.
+ 
 - Runtime config initialization (`init_runtime`) and stricter config validation.
 - Improved webhook handling with optional static token validation.
 - Notifiarr payload handling hardened and JSON field handling made safer.
@@ -11,7 +11,5 @@ Highlights
 
 Notes
 
-- Console log level can be controlled via `LOG_LEVEL`.
-- JSON logs are written to `logs/script.log`.
+ 
 - See README for updated usage examples (list-ids, token generation, server run).
-

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,7 +1,7 @@
 # The URL of your Overseerr instance
 OVERSEERR_BASEURL: "http://127.0.0.1:5055"
 
-# If true, OverFiltrr logs actions but does not update/approve requests
+# If true, OverFiltrr simulates actions but does not update/approve requests
 DRY_RUN: false
 
 # Control whether OverFiltrr auto-approves requests after updating them

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -263,16 +263,12 @@ class RequestCard:
     def _steps_table(self) -> Table:
         table = Table.grid(padding=(0, 1))
         table.add_column(justify="left")
-        table.add_column(justify="right", no_wrap=True)
         for s in self.steps:
             mark = "✓" if s.ok else ("✗" if s.ok is not None else "…")
             if self.cfg.get("ascii"):
                 mark = "+" if s.ok else ("-" if s.ok is not None else ".")
             left = f"{mark} {s.name}"
-            right = ""
-            if s.delta_ms is not None and s.cumulative_ms is not None:
-                right = f"Δ {s.delta_ms:>3} ms  Σ {s.cumulative_ms:>3} ms"
-            table.add_row(left, right)
+            table.add_row(left)
         return table
 
     def set_scoring(self, table: List[Tuple[str, int, int, List[str]]]):
@@ -352,7 +348,7 @@ class RequestCard:
         except Exception:
             pass
 
-        wide = width >= 100
+        wide = width >= 80
         if wide:
             body = Table.grid(expand=True)
             body.add_row(self._meta_text())
@@ -408,7 +404,7 @@ class RequestCard:
     def live(self):
         if HAVE_RICH and self._console is not None and self.cfg.get("enabled", True):
             panel = self._build_panel()
-            with Live(panel, console=self._console, refresh_per_second=8) as live:
+            with Live(panel, console=self._console, refresh_per_second=8, transient=True) as live:
                 self._live = live
                 try:
                     yield self

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -524,13 +524,8 @@ def init_logging(cfg: Dict[str, Any]):
         encoder_choice = (log_cfg.get("JSON") or {}).get("encoder", "auto")
         use_orjson = HAVE_ORJSON if encoder_choice in ("auto", "orjson") else False
 
-        if HAVE_JSON_LOGGER:
-            fmt = jsonlogger.JsonFormatter(
-                defaults={"ts": None},
-            )
-            file_handler.setFormatter(fmt)
-        else:
-            file_handler.setFormatter(NDJSONFormatter(use_orjson=use_orjson))
+        # Prefer built-in NDJSON formatter for stable schema
+        file_handler.setFormatter(NDJSONFormatter(use_orjson=use_orjson))
 
         file_handler.addFilter(ctx_filter)
 

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -187,7 +187,8 @@ class RequestCard:
     tmdb_id: Optional[str] = None
     user: Optional[str] = None
     scored_table: List[Tuple[str, int, int, List[str]]] = field(default_factory=list)
-    scoring_note: Optional[str] = None
+    scoring_note_top: Optional[str] = None
+    scoring_note_bottom: Optional[str] = None
 
     _last_step_time: Optional[datetime] = None
     _console: Optional[Console] = None
@@ -299,13 +300,37 @@ class RequestCard:
 
     def set_scoring(self, table: List[Tuple[str, int, int, List[str]]]):
         try:
-            self.scored_table = table or []
+            cleaned: List[Tuple[str, int, int, List[str]]] = []
+            bottom_note: Optional[str] = None
+            for (name, score, weight, reasons) in (table or []):
+                rs: List[str] = []
+                for r in (reasons or []):
+                    try:
+                        s = str(r)
+                    except Exception:
+                        s = None
+                    if s and "blocked by ceiling" in s.lower():
+                        if bottom_note is None:
+                            bottom_note = s
+                        # omit from per-row reasons; show as footer instead
+                        continue
+                    if s:
+                        rs.append(s)
+                cleaned.append((name, int(score), int(weight), rs))
+            self.scored_table = cleaned
+            if bottom_note:
+                self.scoring_note_bottom = bottom_note
             self.refresh()
         except Exception:
             self.scored_table = []
 
     def set_scoring_note(self, note: Optional[str]):
-        self.scoring_note = note
+        # Back-compat: treat as top note
+        self.scoring_note_top = note
+        self.refresh()
+
+    def set_scoring_footer(self, note: Optional[str]):
+        self.scoring_note_bottom = note
         self.refresh()
 
     def _score_color(self, ratio: float) -> str:
@@ -338,9 +363,6 @@ class RequestCard:
 
         rows = sorted(self.scored_table, key=lambda r: (r[1], r[2], r[0]), reverse=True)
         max_score = max(1, max((r[1] for r in rows), default=1))
-        if self.scoring_note:
-            note = Text(self.scoring_note, style="dim")
-            tbl.add_row(note, Text(""), Text(""), Text(""), Text(""))
 
         for (name, score, weight, reasons) in rows:
             ratio = (score / max_score) if max_score else 0.0
@@ -396,7 +418,15 @@ class RequestCard:
 
             right = Table.grid(expand=True)
             right.add_row(Text("Scoring", style="bold"))
-            right.add_row(self._build_scoring_table(width // 2))
+            # Build a one-column section so notes can span full scoring width
+            scoring_section = Table.grid(expand=True)
+            scoring_section.add_column(ratio=1)
+            if self.scoring_note_top:
+                scoring_section.add_row(Text(self.scoring_note_top, style="dim"))
+            scoring_section.add_row(self._build_scoring_table(width // 2))
+            if self.scoring_note_bottom:
+                scoring_section.add_row(Text(self.scoring_note_bottom, style="dim"))
+            right.add_row(scoring_section)
 
             columns.add_row(left, right)
             body.add_row(columns)
@@ -414,7 +444,15 @@ class RequestCard:
             if self.scored_table:
                 body.add_row(Text())
                 body.add_row(Text("Scoring", style="bold"))
-                body.add_row(self._build_scoring_table(width))
+                # In narrow layout, also use a one-column section for full-width notes
+                scoring_section = Table.grid(expand=True)
+                scoring_section.add_column(ratio=1)
+                if self.scoring_note_top:
+                    scoring_section.add_row(Text(self.scoring_note_top, style="dim"))
+                scoring_section.add_row(self._build_scoring_table(width))
+                if self.scoring_note_bottom:
+                    scoring_section.add_row(Text(self.scoring_note_bottom, style="dim"))
+                body.add_row(scoring_section)
             if self.decision_line:
                 body.add_row(Text())
                 body.add_row(Text("─ Decision ─", style="bold"))

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -562,3 +562,78 @@ def init_logging(cfg: Dict[str, Any]):
             logging.getLogger(noisy).setLevel(max(level, logging.WARNING))
         except Exception:
             pass
+
+
+# =========================
+# Startup card
+# =========================
+def render_startup_card(*, cfg: Dict[str, Any], host: str, port: int, threads: int, connection_limit: int, ok: bool = True, message: Optional[str] = None) -> None:
+    try:
+        ccfg = (cfg.get("LOGGING") or {}).get("CONSOLE") or {}
+    except Exception:
+        ccfg = {}
+
+    status_color = "green" if ok else "red"
+    status_text = "READY" if ok else "ERROR"
+
+    # Gather details
+    try:
+        dry_run = bool(cfg.get("DRY_RUN", False))
+        allow_auto = bool(cfg.get("ALLOW_AUTO_APPROVE", True))
+        overseerr = str(cfg.get("OVERSEERR_BASEURL", ""))
+        wcfg = cfg.get("WEBHOOK") or {}
+        token_enabled = bool(wcfg.get("TOKEN"))
+        fcfg = (cfg.get("LOGGING") or {}).get("FILE") or {}
+        file_enabled = fcfg.get("enabled", True)
+        file_path = fcfg.get("path", os.path.join("logs", "overfiltrr.log"))
+        console_enabled = (cfg.get("LOGGING") or {}).get("CONSOLE", {}).get("enabled", True)
+        ascii_mode = (cfg.get("LOGGING") or {}).get("CONSOLE", {}).get("ascii", False)
+    except Exception:
+        dry_run = False; allow_auto = True; overseerr = ""
+        token_enabled = False; file_enabled = True; file_path = "logs/overfiltrr.log"
+        console_enabled = True; ascii_mode = False
+
+    if HAVE_RICH and console_enabled:
+        try:
+            console = Console(log_time=False, log_path=False, highlight=False)
+            table = Table.grid(padding=(0, 2))
+            table.add_column(justify="left")
+            table.add_column(justify="left")
+
+            def add_row(k: str, v: str):
+                table.add_row(Text(k, style="dim"), Text(v, style="bold"))
+
+            add_row("Config", "OK" if ok else "INVALID")
+            if message:
+                add_row("Note", message)
+            add_row("Overseerr", overseerr or "(unset)")
+            add_row("Mode", "DRY-RUN" if dry_run else "ENFORCED")
+            add_row("Auto-approve", "ON" if allow_auto else "OFF")
+            add_row("Webhook token", "ENABLED" if token_enabled else "disabled")
+            add_row("Server", f"{host}:{port}")
+            add_row("Threads", str(threads))
+            add_row("Conn limit", str(connection_limit))
+            add_row("Console logging", "ON" if console_enabled else "OFF")
+            add_row("ASCII", "ON" if ascii_mode else "OFF")
+            add_row("File logging", f"ON → {file_path}" if file_enabled else "OFF")
+
+            panel = Panel(
+                table,
+                title=Text(f" OverFiltrr • {status_text} ", style=f"bold {status_color}"),
+                border_style=status_color,
+                box=box.ASCII if ccfg.get("ascii") else box.ROUNDED,
+            )
+            console.print(panel)
+            return
+        except Exception:
+            pass
+
+    # Plain fallback
+    print(f"OverFiltrr {status_text}")
+    if message:
+        print(f"  Note: {message}")
+    print(f"  Overseerr: {overseerr}")
+    print(f"  Mode: {'DRY-RUN' if dry_run else 'ENFORCED'}; Auto-approve: {'ON' if allow_auto else 'OFF'}")
+    print(f"  Server: {host}:{port}  Threads: {threads}  Conn limit: {connection_limit}")
+    print(f"  Console logging: {'ON' if console_enabled else 'OFF'}  ASCII: {'ON' if ascii_mode else 'OFF'}")
+    print(f"  File logging: {'ON' if file_enabled else 'OFF'}  Path: {file_path}")

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -592,10 +592,15 @@ def render_startup_card(*, cfg: Dict[str, Any], host: str, port: int, threads: i
         file_path = fcfg.get("path", os.path.join("logs", "overfiltrr.log"))
         console_enabled = (cfg.get("LOGGING") or {}).get("CONSOLE", {}).get("enabled", True)
         ascii_mode = (cfg.get("LOGGING") or {}).get("CONSOLE", {}).get("ascii", False)
+        level_name = str((cfg.get("LOGGING") or {}).get("LEVEL", "INFO")).upper()
     except Exception:
         dry_run = False; allow_auto = True; overseerr = ""
         token_enabled = False; file_enabled = True; file_path = "logs/overfiltrr.log"
         console_enabled = True; ascii_mode = False
+        try:
+            level_name = logging.getLevelName(logging.getLogger().level)
+        except Exception:
+            level_name = "INFO"
 
     if HAVE_RICH and console_enabled:
         try:
@@ -616,6 +621,15 @@ def render_startup_card(*, cfg: Dict[str, Any], host: str, port: int, threads: i
             add_row("Auto-approve", Text("ON" if allow_auto else "OFF", style=("bold green" if allow_auto else "bold red")))
             add_row("Webhook token", Text("ENABLED" if token_enabled else "disabled", style=("bold cyan" if token_enabled else "dim")))
             add_row("Server", Text(f"{host}:{port}", style="bold blue"))
+            # Logging level with color cue
+            level_style = {
+                "DEBUG": "bold yellow",
+                "INFO": "bold green",
+                "WARNING": "bold yellow",
+                "ERROR": "bold red",
+                "CRITICAL": "bold red",
+            }.get(level_name, "bold")
+            add_row("Logging level", Text(level_name, style=level_style))
             add_row("Console logging", Text("ON" if console_enabled else "OFF", style=("bold green" if console_enabled else "bold red")))
             add_row("ASCII", Text("ON" if ascii_mode else "OFF", style=("bold magenta" if ascii_mode else "dim")))
             if file_enabled:
@@ -641,5 +655,6 @@ def render_startup_card(*, cfg: Dict[str, Any], host: str, port: int, threads: i
     print(f"  Overseerr: {overseerr}")
     print(f"  Dry run: {'ON' if dry_run else 'OFF'}; Auto-approve: {'ON' if allow_auto else 'OFF'}")
     print(f"  Server: {host}:{port}")
+    print(f"  Logging level: {level_name}")
     print(f"  Console logging: {'ON' if console_enabled else 'OFF'}  ASCII: {'ON' if ascii_mode else 'OFF'}")
     print(f"  File logging: {'ON' if file_enabled else 'OFF'}  Path: {file_path}")

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -1,0 +1,568 @@
+import logging
+import logging.handlers
+import os
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    # Optional console dependency
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+    from rich.text import Text
+    from rich import box
+    from rich.live import Live
+    from rich.traceback import install as rich_traceback_install
+    HAVE_RICH = True
+except Exception:
+    HAVE_RICH = False
+
+try:
+    # Optional faster JSON
+    import orjson  # type: ignore
+    HAVE_ORJSON = True
+except Exception:
+    HAVE_ORJSON = False
+
+try:
+    # Optional structured formatter
+    from pythonjsonlogger import jsonlogger  # type: ignore
+    HAVE_JSON_LOGGER = True
+except Exception:
+    HAVE_JSON_LOGGER = False
+
+import queue
+import contextvars
+import json
+
+
+# =========================
+# Context
+# =========================
+cv_correlation_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("correlation_id", default=None)
+cv_request_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("request_id", default=None)
+cv_media_type: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("media_type", default=None)
+cv_tmdb_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("tmdb_id", default=None)
+cv_user: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("user", default=None)
+
+
+def set_context(**kwargs):
+    if "correlation_id" in kwargs:
+        cv_correlation_id.set(kwargs.get("correlation_id"))
+    if "request_id" in kwargs:
+        cv_request_id.set(kwargs.get("request_id"))
+    if "media_type" in kwargs:
+        cv_media_type.set(kwargs.get("media_type"))
+    if "tmdb_id" in kwargs:
+        cv_tmdb_id.set(kwargs.get("tmdb_id"))
+    if "user" in kwargs:
+        cv_user.set(kwargs.get("user"))
+
+
+class ContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Inject contextvars into every record
+        for name, cv in (
+            ("correlation_id", cv_correlation_id),
+            ("request_id", cv_request_id),
+            ("media_type", cv_media_type),
+            ("tmdb_id", cv_tmdb_id),
+            ("user", cv_user),
+        ):
+            if not hasattr(record, name) or getattr(record, name) is None:
+                try:
+                    setattr(record, name, cv.get())
+                except Exception:
+                    setattr(record, name, None)
+        return True
+
+
+def get_logger(name: str = "overfiltrr") -> logging.Logger:
+    return logging.getLogger(name)
+
+
+# =========================
+# JSON formatter (fallback if python-json-logger is absent)
+# =========================
+class NDJSONFormatter(logging.Formatter):
+    """Simple JSON Line formatter with stable keys."""
+
+    def __init__(self, *, use_orjson: bool = False):
+        super().__init__()
+        self.use_orjson = use_orjson and HAVE_ORJSON
+
+    def format(self, record: logging.LogRecord) -> str:
+        base: Dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            # context
+            "correlation_id": getattr(record, "correlation_id", None),
+            "request_id": getattr(record, "request_id", None),
+            "media_type": getattr(record, "media_type", None),
+            "tmdb_id": getattr(record, "tmdb_id", None),
+            "user": getattr(record, "user", None),
+        }
+        # Common optional fields
+        for k in (
+            "event",
+            "step",
+            "ok",
+            "delta_ms",
+            "cumulative_ms",
+            "decision",
+            "category",
+            "root",
+            "profile_id",
+            "score_total",
+            "exc_type",
+            "exc_msg",
+            "exc_stack",
+        ):
+            v = getattr(record, k, None)
+            if v is not None:
+                base[k] = v
+
+        try:
+            if self.use_orjson:
+                return orjson.dumps(base).decode("utf-8")
+            return json.dumps(base, ensure_ascii=False, separators=(",", ":"))
+        except Exception:
+            # Fallback to a minimal, safe line
+            return f"{base.get('ts')} {record.levelname} {record.getMessage()}"
+
+
+# =========================
+# Console Card Renderer (minimal, live-capable)
+# =========================
+@dataclass
+class Step:
+    name: str
+    ok: Optional[bool] = None
+    delta_ms: Optional[int] = None
+    cumulative_ms: Optional[int] = None
+
+
+@dataclass
+class RequestCard:
+    cfg: Dict[str, Any]
+    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    title: str = ""
+    status: str = "running"  # accepted|failed|aborted|rejected|running
+    steps: List[Step] = field(default_factory=list)
+    decision_line: Optional[str] = None
+    media_type: Optional[str] = None
+    dry_run: bool = False
+    correlation_id: Optional[str] = None
+    request_id: Optional[str] = None
+    tmdb_id: Optional[str] = None
+    user: Optional[str] = None
+    scored_table: List[Tuple[str, int, int, List[str]]] = field(default_factory=list)
+
+    _last_step_time: Optional[datetime] = None
+    _console: Optional[Console] = None
+    _live: Optional[Live] = None
+
+    def attach_console(self, console: Optional[Console]) -> None:
+        self._console = console
+
+    def _now_ms(self) -> int:
+        return int((datetime.now(timezone.utc) - self.started_at).total_seconds() * 1000)
+
+    @contextmanager
+    def step(self, name: str):
+        s = Step(name=name)
+        self.steps.append(s)
+        start = datetime.now(timezone.utc)
+        try:
+            self.refresh()
+            yield s
+            ok = True
+        except Exception:
+            ok = False
+            raise
+        finally:
+            end = datetime.now(timezone.utc)
+            delta_ms = int((end - start).total_seconds() * 1000)
+            cumulative_ms = int((end - self.started_at).total_seconds() * 1000)
+            s.ok = ok
+            s.delta_ms = delta_ms
+            s.cumulative_ms = cumulative_ms
+            self._last_step_time = end
+            self.refresh()
+
+    def set_meta(self, *, title: Optional[str] = None, media_type: Optional[str] = None,
+                 correlation_id: Optional[str] = None, request_id: Optional[str] = None,
+                 tmdb_id: Optional[str] = None, user: Optional[str] = None,
+                 dry_run: Optional[bool] = None):
+        if title is not None:
+            self.title = title
+        if media_type is not None:
+            self.media_type = media_type
+        if correlation_id is not None:
+            self.correlation_id = correlation_id
+        if request_id is not None:
+            self.request_id = request_id
+        if tmdb_id is not None:
+            self.tmdb_id = tmdb_id
+        if user is not None:
+            self.user = user
+        if dry_run is not None:
+            self.dry_run = bool(dry_run)
+        self.refresh()
+
+    def set_status(self, status: str):
+        # accepted|failed|aborted|rejected
+        self.status = status
+        self.refresh()
+
+    def set_decision(self, line: str):
+        self.decision_line = line
+        self.refresh()
+
+    def refresh(self):
+        if not HAVE_RICH:
+            return  # No-op; plain mode prints only at end
+        if not self._live:
+            return
+        try:
+            self._live.update(self._build_panel())
+        except Exception:
+            pass
+
+    def _badge_text(self) -> Text:
+        t = Text()
+        # Media type badge
+        if self.media_type:
+            color = "blue" if self.media_type == "movie" else "magenta"
+            t.append(f" [ {self.media_type.upper()} ] ", style=f"bold {color}")
+        # Dry run
+        if self.dry_run:
+            t.append(" [ DRY-RUN ] ", style="bold yellow")
+        # Status
+        status_color = {
+            "accepted": "green",
+            "running": "cyan",
+            "failed": "red",
+            "aborted": "yellow",
+            "rejected": "red",
+        }.get(self.status, "cyan")
+        t.append(f" [ {self.status.upper()} ] ", style=f"bold {status_color}")
+        # Corr id
+        if self.correlation_id:
+            t.append(f"    corr={self.correlation_id[:8]}", style="dim")
+        # Clock and duration
+        dur_s = (datetime.now(timezone.utc) - self.started_at).total_seconds()
+        t.append(f"    · {dur_s:.2f}s", style="dim")
+        return t
+
+    def _steps_table(self) -> Table:
+        table = Table.grid(padding=(0, 1))
+        table.add_column(justify="left")
+        table.add_column(justify="right", no_wrap=True)
+        for s in self.steps:
+            mark = "✓" if s.ok else ("✗" if s.ok is not None else "…")
+            if self.cfg.get("ascii"):
+                mark = "+" if s.ok else ("-" if s.ok is not None else ".")
+            left = f"{mark} {s.name}"
+            right = ""
+            if s.delta_ms is not None and s.cumulative_ms is not None:
+                right = f"Δ {s.delta_ms:>3} ms  Σ {s.cumulative_ms:>3} ms"
+            table.add_row(left, right)
+        return table
+
+    def set_scoring(self, table: List[Tuple[str, int, int, List[str]]]):
+        try:
+            self.scored_table = table or []
+            self.refresh()
+        except Exception:
+            self.scored_table = []
+
+    def _score_color(self, ratio: float) -> str:
+        if ratio >= 0.75:
+            return "green"
+        if ratio >= 0.4:
+            return "yellow"
+        return "red"
+
+    def _score_bar(self, filled: int, total: int, style: str) -> Text:
+        filled = max(0, min(total, int(filled)))
+        empty = max(0, total - filled)
+        if self.cfg.get("ascii"):
+            bar = "#" * filled + "." * empty
+            return Text(bar, style=style)
+        else:
+            bar = "█" * filled + "·" * empty
+            return Text(bar, style=style)
+
+    def _build_scoring_table(self, width: int) -> Table:
+        tbl = Table.grid(padding=(0, 1))
+        tbl.add_column("", justify="left")
+        tbl.add_column("", justify="left", ratio=1)
+        tbl.add_column("", justify="right", no_wrap=True)
+        tbl.add_column("", justify="right", no_wrap=True)
+        tbl.add_column("", justify="left")
+
+        if not self.scored_table:
+            return tbl
+
+        rows = sorted(self.scored_table, key=lambda r: (r[1], r[2], r[0]), reverse=True)
+        max_score = max(1, max((r[1] for r in rows), default=1))
+
+        for (name, score, weight, reasons) in rows:
+            ratio = (score / max_score) if max_score else 0.0
+            filled = int(round(ratio * 10))
+            style = self._score_color(ratio)
+            bar = self._score_bar(filled, 10, style)
+
+            shown = reasons[:2]
+            more = len(reasons) - len(shown)
+            reason_txt = ", ".join([r for r in shown if r])
+            if more > 0:
+                if reason_txt:
+                    reason_txt += f"  +{more} more"
+                else:
+                    reason_txt = f"+{more} more"
+
+            tbl.add_row(Text(name, style="bold"), bar, Text(str(score)), Text(str(weight)), Text(reason_txt))
+        return tbl
+
+    def _meta_text(self) -> Text:
+        parts = []
+        if self.title:
+            parts.append(f"Title: {self.title}")
+        if self.tmdb_id:
+            parts.append(f"tmdb={self.tmdb_id}")
+        if self.request_id:
+            parts.append(f"req={self.request_id}")
+        if self.user:
+            parts.append(f"by={self.user}")
+        return Text("    ".join(parts))
+
+    def _build_panel(self) -> Panel:
+        header = self._badge_text()
+        width = 100
+        try:
+            if self._console:
+                width = max(40, int(self._console.size.width))
+        except Exception:
+            pass
+
+        wide = width >= 100
+        if wide:
+            body = Table.grid(expand=True)
+            body.add_row(self._meta_text())
+            body.add_row(Text())
+            columns = Table.grid(expand=True)
+            columns.add_column(ratio=1)
+            columns.add_column(ratio=1)
+
+            left = Table.grid(expand=True)
+            left.add_row(Text("Steps", style="bold"))
+            left.add_row(self._steps_table())
+
+            right = Table.grid(expand=True)
+            right.add_row(Text("Scoring", style="bold"))
+            right.add_row(self._build_scoring_table(width // 2))
+
+            columns.add_row(left, right)
+            body.add_row(columns)
+
+            if self.decision_line:
+                body.add_row(Text())
+                body.add_row(Text("─ Decision ─", style="bold"))
+                body.add_row(Text(self.decision_line))
+        else:
+            body = Table.grid(expand=True)
+            body.add_row(self._meta_text())
+            body.add_row(Text())
+            body.add_row(Text("Steps", style="bold"))
+            body.add_row(self._steps_table())
+            if self.scored_table:
+                body.add_row(Text())
+                body.add_row(Text("Scoring", style="bold"))
+                body.add_row(self._build_scoring_table(width))
+            if self.decision_line:
+                body.add_row(Text())
+                body.add_row(Text("─ Decision ─", style="bold"))
+                body.add_row(Text(self.decision_line))
+        status_color = {
+            "accepted": "green",
+            "running": "cyan",
+            "failed": "red",
+            "aborted": "yellow",
+            "rejected": "red",
+        }.get(self.status, "cyan")
+        return Panel(
+            body,
+            title=header,
+            border_style=status_color,
+            box=box.ASCII if self.cfg.get("ascii") else box.ROUNDED,
+        )
+
+    @contextmanager
+    def live(self):
+        if HAVE_RICH and self._console is not None and self.cfg.get("enabled", True):
+            panel = self._build_panel()
+            with Live(panel, console=self._console, refresh_per_second=8) as live:
+                self._live = live
+                try:
+                    yield self
+                finally:
+                    self._live = None
+        else:
+            # Plain mode: nothing to render live
+            yield self
+
+    def final_render(self):
+        if HAVE_RICH and self._console is not None and self.cfg.get("enabled", True):
+            try:
+                self._console.print(self._build_panel())
+            except Exception:
+                pass
+        else:
+            # Plain text fallback
+            dur = (datetime.now(timezone.utc) - self.started_at).total_seconds()
+            print(f"[{self.media_type or '?'}]{' [DRY-RUN]' if self.dry_run else ''} {self.status.upper()} corr={str(self.correlation_id)[:8]} · {dur:.2f}s")
+            if self.title:
+                bits = []
+                if self.tmdb_id:
+                    bits.append(f"tmdb={self.tmdb_id}")
+                if self.request_id:
+                    bits.append(f"req={self.request_id}")
+                if self.user:
+                    bits.append(f"by={self.user}")
+                print(f"Title: {self.title}  {'  '.join(bits)}")
+            print("Steps")
+            for s in self.steps:
+                mark = "+" if s.ok else ("-" if s.ok is not None else ".")
+                right = ""
+                if s.delta_ms is not None and s.cumulative_ms is not None:
+                    right = f"  (Δ {s.delta_ms} ms  Σ {s.cumulative_ms} ms)"
+                print(f"  {mark} {s.name}{right}")
+            if self.decision_line:
+                print("Decision")
+                print(f"  {self.decision_line}")
+
+
+# Track current card in context to avoid threading params through everywhere
+cv_card: contextvars.ContextVar[Optional[RequestCard]] = contextvars.ContextVar("_card", default=None)
+
+
+def get_current_card() -> Optional[RequestCard]:
+    try:
+        return cv_card.get()
+    except Exception:
+        return None
+
+
+def new_request_card(cfg: Dict[str, Any]) -> RequestCard:
+    console = Console(log_time=False, log_path=False, highlight=False) if HAVE_RICH else None
+    card = RequestCard(cfg={
+        "enabled": bool(cfg.get("enabled", True)),
+        "ascii": bool(cfg.get("ascii", False)),
+    })
+    card.attach_console(console)
+    cv_card.set(card)
+    return card
+
+
+def end_request_card():
+    card = get_current_card()
+    if card:
+        card.final_render()
+    cv_card.set(None)
+
+
+# =========================
+# Initialisation
+# =========================
+_listener: Optional[logging.handlers.QueueListener] = None
+
+
+def _ensure_dir(path: str) -> None:
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+    except Exception:
+        pass
+
+
+def init_logging(cfg: Dict[str, Any]):
+    global _listener
+
+    log_cfg = cfg.get("LOGGING") if isinstance(cfg, dict) else None
+    log_cfg = log_cfg or {}
+
+    level_name = str(log_cfg.get("LEVEL", "INFO")).upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    # Remove any pre-existing handlers to avoid duplicate logs
+    for h in list(root.handlers):
+        try:
+            root.removeHandler(h)
+        except Exception:
+            pass
+
+    # Common context filter
+    ctx_filter = ContextFilter()
+
+    # File logging (async NDJSON)
+    fcfg = (log_cfg.get("FILE") or {}) if isinstance(log_cfg, dict) else {}
+    if fcfg.get("enabled", True):
+        path = fcfg.get("path", os.path.join("logs", "overfiltrr.log"))
+        _ensure_dir(path)
+        when = (fcfg.get("rotate") or {}).get("when", "midnight")
+        backup_count = int((fcfg.get("rotate") or {}).get("backup_count", 7))
+        file_handler = logging.handlers.TimedRotatingFileHandler(
+            filename=path, when=when, backupCount=backup_count, encoding="utf-8"
+        )
+
+        # Structured formatter
+        encoder_choice = (log_cfg.get("JSON") or {}).get("encoder", "auto")
+        use_orjson = HAVE_ORJSON if encoder_choice in ("auto", "orjson") else False
+
+        if HAVE_JSON_LOGGER:
+            fmt = jsonlogger.JsonFormatter(
+                defaults={"ts": None},
+            )
+            file_handler.setFormatter(fmt)
+        else:
+            file_handler.setFormatter(NDJSONFormatter(use_orjson=use_orjson))
+
+        file_handler.addFilter(ctx_filter)
+
+        q: queue.Queue = queue.Queue(-1)
+        qh = logging.handlers.QueueHandler(q)
+        qh.addFilter(ctx_filter)
+        root.addHandler(qh)
+
+        try:
+            _listener = logging.handlers.QueueListener(q, file_handler)
+            _listener.daemon = True
+            _listener.start()
+        except Exception:
+            # Fallback to direct handler if listener fails
+            root.removeHandler(qh)
+            root.addHandler(file_handler)
+
+    # Console: install rich traceback if available
+    ccfg = (log_cfg.get("CONSOLE") or {}) if isinstance(log_cfg, dict) else {}
+    if HAVE_RICH and ccfg.get("enabled", True):
+        try:
+            rich_traceback_install(show_locals=False, suppress=["urllib3", "requests"])  # type: ignore
+        except Exception:
+            pass
+
+    # Quiet noisy libraries a bit
+    for noisy in ("werkzeug", "waitress", "urllib3"):
+        try:
+            logging.getLogger(noisy).setLevel(max(level, logging.WARNING))
+        except Exception:
+            pass

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
+import atexit
 
 try:
     # Optional console dependency
@@ -88,15 +89,25 @@ def get_logger(name: str = "overfiltrr") -> logging.Logger:
 # JSON formatter (fallback if python-json-logger is absent)
 # =========================
 class NDJSONFormatter(logging.Formatter):
-    """Simple JSON Line formatter with stable keys."""
+    """Simple JSON Line formatter with stable keys.
+
+    Notes:
+    - Uses record.created (UTC) for ts to reflect emit time.
+    - Includes traceback when exc_info/stack_info are present.
+    """
 
     def __init__(self, *, use_orjson: bool = False):
         super().__init__()
         self.use_orjson = use_orjson and HAVE_ORJSON
 
     def format(self, record: logging.LogRecord) -> str:
+        try:
+            ts = datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+        except Exception:
+            ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
         base: Dict[str, Any] = {
-            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "ts": ts,
             "level": record.levelname,
             "logger": record.name,
             "message": record.getMessage(),
@@ -107,6 +118,7 @@ class NDJSONFormatter(logging.Formatter):
             "tmdb_id": getattr(record, "tmdb_id", None),
             "user": getattr(record, "user", None),
         }
+
         # Common optional fields
         for k in (
             "event",
@@ -127,6 +139,18 @@ class NDJSONFormatter(logging.Formatter):
             v = getattr(record, k, None)
             if v is not None:
                 base[k] = v
+
+        # Derive exception/stack details from the record when present
+        try:
+            if record.exc_info and not base.get("exc_stack"):
+                base["exc_stack"] = self.formatException(record.exc_info)
+        except Exception:
+            pass
+        try:
+            if record.stack_info and not base.get("exc_stack"):
+                base["exc_stack"] = record.stack_info
+        except Exception:
+            pass
 
         try:
             if self.use_orjson:
@@ -525,8 +549,14 @@ def init_logging(cfg: Dict[str, Any]):
         _ensure_dir(path)
         when = (fcfg.get("rotate") or {}).get("when", "midnight")
         backup_count = int((fcfg.get("rotate") or {}).get("backup_count", 7))
+        # Use UTC-based rotation and delay file open until first emit
         file_handler = logging.handlers.TimedRotatingFileHandler(
-            filename=path, when=when, backupCount=backup_count, encoding="utf-8"
+            filename=path,
+            when=when,
+            backupCount=backup_count,
+            encoding="utf-8",
+            utc=True,
+            delay=True,
         )
 
         # Structured formatter
@@ -566,6 +596,27 @@ def init_logging(cfg: Dict[str, Any]):
             logging.getLogger(noisy).setLevel(max(level, logging.WARNING))
         except Exception:
             pass
+
+    # Ensure graceful shutdown flushes the queue
+    try:
+        atexit.register(shutdown_logging)
+    except Exception:
+        pass
+
+
+def shutdown_logging():
+    """Flush and stop async listeners/handlers safely.
+
+    Registered via atexit from init_logging().
+    """
+    global _listener
+    try:
+        if _listener is not None:
+            _listener.stop()
+    except Exception:
+        pass
+    finally:
+        _listener = None
 
 
 # =========================

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -119,6 +119,7 @@ class NDJSONFormatter(logging.Formatter):
             "root",
             "profile_id",
             "score_total",
+            "scores",
             "exc_type",
             "exc_msg",
             "exc_stack",
@@ -162,6 +163,7 @@ class RequestCard:
     tmdb_id: Optional[str] = None
     user: Optional[str] = None
     scored_table: List[Tuple[str, int, int, List[str]]] = field(default_factory=list)
+    scoring_note: Optional[str] = None
 
     _last_step_time: Optional[datetime] = None
     _console: Optional[Console] = None
@@ -278,6 +280,10 @@ class RequestCard:
         except Exception:
             self.scored_table = []
 
+    def set_scoring_note(self, note: Optional[str]):
+        self.scoring_note = note
+        self.refresh()
+
     def _score_color(self, ratio: float) -> str:
         if ratio >= 0.75:
             return "green"
@@ -308,6 +314,9 @@ class RequestCard:
 
         rows = sorted(self.scored_table, key=lambda r: (r[1], r[2], r[0]), reverse=True)
         max_score = max(1, max((r[1] for r in rows), default=1))
+        if self.scoring_note:
+            note = Text(self.scoring_note, style="dim")
+            tbl.add_row(note, Text(""), Text(""), Text(""), Text(""))
 
         for (name, score, weight, reasons) in rows:
             ratio = (score / max_score) if max_score else 0.0

--- a/logging_setup.py
+++ b/logging_setup.py
@@ -600,22 +600,24 @@ def render_startup_card(*, cfg: Dict[str, Any], host: str, port: int, threads: i
             table.add_column(justify="left")
             table.add_column(justify="left")
 
-            def add_row(k: str, v: str):
-                table.add_row(Text(k, style="dim"), Text(v, style="bold"))
+            def add_row(k: str, v: str | Text):
+                v_text = v if isinstance(v, Text) else Text(v)
+                table.add_row(Text(k, style="dim"), v_text)
 
-            add_row("Config", "OK" if ok else "INVALID")
+            add_row("Config", Text("OK" if ok else "INVALID", style=("bold green" if ok else "bold red")))
             if message:
                 add_row("Note", message)
-            add_row("Overseerr", overseerr or "(unset)")
-            add_row("Mode", "DRY-RUN" if dry_run else "ENFORCED")
-            add_row("Auto-approve", "ON" if allow_auto else "OFF")
-            add_row("Webhook token", "ENABLED" if token_enabled else "disabled")
-            add_row("Server", f"{host}:{port}")
-            add_row("Threads", str(threads))
-            add_row("Conn limit", str(connection_limit))
-            add_row("Console logging", "ON" if console_enabled else "OFF")
-            add_row("ASCII", "ON" if ascii_mode else "OFF")
-            add_row("File logging", f"ON → {file_path}" if file_enabled else "OFF")
+            add_row("Overseerr", Text(overseerr or "(unset)", style="bold blue"))
+            add_row("Dry run", Text("ON" if dry_run else "OFF", style=("bold orange3" if dry_run else "bold green")))
+            add_row("Auto-approve", Text("ON" if allow_auto else "OFF", style=("bold green" if allow_auto else "bold red")))
+            add_row("Webhook token", Text("ENABLED" if token_enabled else "disabled", style=("bold cyan" if token_enabled else "dim")))
+            add_row("Server", Text(f"{host}:{port}", style="bold blue"))
+            add_row("Console logging", Text("ON" if console_enabled else "OFF", style=("bold green" if console_enabled else "bold red")))
+            add_row("ASCII", Text("ON" if ascii_mode else "OFF", style=("bold magenta" if ascii_mode else "dim")))
+            if file_enabled:
+                add_row("File logging", Text(f"ON → {file_path}", style="bold green"))
+            else:
+                add_row("File logging", Text("OFF", style="bold red"))
 
             panel = Panel(
                 table,
@@ -633,7 +635,7 @@ def render_startup_card(*, cfg: Dict[str, Any], host: str, port: int, threads: i
     if message:
         print(f"  Note: {message}")
     print(f"  Overseerr: {overseerr}")
-    print(f"  Mode: {'DRY-RUN' if dry_run else 'ENFORCED'}; Auto-approve: {'ON' if allow_auto else 'OFF'}")
-    print(f"  Server: {host}:{port}  Threads: {threads}  Conn limit: {connection_limit}")
+    print(f"  Dry run: {'ON' if dry_run else 'OFF'}; Auto-approve: {'ON' if allow_auto else 'OFF'}")
+    print(f"  Server: {host}:{port}")
     print(f"  Console logging: {'ON' if console_enabled else 'OFF'}  ASCII: {'ON' if ascii_mode else 'OFF'}")
     print(f"  File logging: {'ON' if file_enabled else 'OFF'}  Path: {file_path}")

--- a/overfiltrr.py
+++ b/overfiltrr.py
@@ -47,6 +47,39 @@ except Exception:
         pass
 
 # =========================
+# Small UI helpers (console-only formatting)
+# =========================
+def _shorten_path_for_display(path: Optional[str], *, keep_parts: int = 3, home_as_tilde: bool = True) -> str:
+    """Return a compact path for console display.
+
+    - Replaces the user's home prefix with "~/" when applicable.
+    - If the path is long, keeps only the last `keep_parts` segments with a leading ellipsis.
+    - Never mutates the path used in file logs; this is console-only.
+    """
+    if not path:
+        return ""
+    s = str(path)
+    prefix = ""
+    try:
+        if home_as_tilde:
+            home = os.path.expanduser("~")
+            if s.startswith(home + "/"):
+                s = "~/" + s[len(home) + 1:]
+    except Exception:
+        pass
+    if s.startswith("~/"):
+        prefix = "~/"
+        rest = s[2:]
+    elif s.startswith("/"):
+        prefix = "/"
+        rest = s[1:]
+    else:
+        rest = s
+    parts = [p for p in rest.split("/") if p]
+    if len(parts) > keep_parts:
+        return f"{prefix}…/" + "/".join(parts[-keep_parts:])
+    return prefix + rest
+# =========================
 # App and global constants
 # =========================
 app = Flask(__name__)
@@ -1356,7 +1389,8 @@ def process_request(request_data: dict, correlation_id: str) -> None:
                     cat_label = f"{best_match} (default)"
         except Exception:
             pass
-        card.set_decision(f"{status_text.upper()}    root={target_root_folder}    category={cat_label}    profile={profile_id}")
+        display_root = _shorten_path_for_display(target_root_folder)
+        card.set_decision(f"{status_text.upper()}    root={display_root}    category={cat_label}    profile={profile_id}")
 
     # File log: decision event with key fields
     try:

--- a/overfiltrr.py
+++ b/overfiltrr.py
@@ -1323,6 +1323,28 @@ def process_request(request_data: dict, correlation_id: str) -> None:
         card.set_status('accepted')
         card.set_decision(f"{status_text.upper()}    root={target_root_folder}    category={best_match}    profile={profile_id}")
 
+    # File log: decision event with key fields
+    try:
+        score_total = None
+        try:
+            # Use scored_table if available to find chosen category score
+            for name, sc, wt, reasons in (locals().get('scored_table') or []):
+                if name == best_match:
+                    score_total = sc
+                    break
+        except Exception:
+            score_total = None
+        logger.info("decision", extra={
+            "event": "decision",
+            "decision": status_text,
+            "category": best_match,
+            "root": target_root_folder,
+            "profile_id": profile_id,
+            "score_total": score_total,
+        })
+    except Exception:
+        pass
+
 # =========================
 # Main
 # =========================

--- a/overfiltrr.py
+++ b/overfiltrr.py
@@ -1159,6 +1159,15 @@ def process_request(request_data: dict, correlation_id: str) -> None:
                     card.set_scoring(scored_table)
                 except Exception:
                     pass
+                try:
+                    logger = get_logger("overfiltrr")
+                    scores_payload = [
+                        {"name": name, "score": sc, "weight": wt, "reasons": reasons}
+                        for (name, sc, wt, reasons) in (scored_table or [])
+                    ]
+                    logger.debug("scoring.table", extra={"event": "scoring.table", "scores": scores_payload})
+                except Exception:
+                    pass
             logger.info("step", extra={"event": "step", "step": "Score categories", "ok": s.ok, "delta_ms": s.delta_ms, "cumulative_ms": s.cumulative_ms})
         else:
             target_root_folder, best_match, scored_table = categorise_media_scored(
@@ -1166,6 +1175,15 @@ def process_request(request_data: dict, correlation_id: str) -> None:
                 media_type,
                 request_id=str(request_id), correlation_id=correlation_id
             )
+            try:
+                logger = get_logger("overfiltrr")
+                scores_payload = [
+                    {"name": name, "score": sc, "weight": wt, "reasons": reasons}
+                    for (name, sc, wt, reasons) in (scored_table or [])
+                ]
+                logger.debug("scoring.table", extra={"event": "scoring.table", "scores": scores_payload})
+            except Exception:
+                pass
 
     if not target_root_folder or not best_match:
         if card:
@@ -1177,6 +1195,15 @@ def process_request(request_data: dict, correlation_id: str) -> None:
     apply_data = folder_data.get('apply') or {}
     default_profile_id = apply_data.get('default_profile_id')
     quality_profile_rules = folder_data.get('quality_profile_rules') or []
+    default_key = categories.get('default')
+
+    try:
+        if card and default_key == best_match:
+            max_sc = max((sc for (_, sc, _, _) in (locals().get('scored_table') or [])), default=0)
+            if max_sc <= 0:
+                card.set_scoring_note("No positive matches; fell back to default")
+    except Exception:
+        pass
 
     context = {
         'release_year': release_year,
@@ -1321,7 +1348,15 @@ def process_request(request_data: dict, correlation_id: str) -> None:
     card = get_current_card()
     if card:
         card.set_status('accepted')
-        card.set_decision(f"{status_text.upper()}    root={target_root_folder}    category={best_match}    profile={profile_id}")
+        cat_label = best_match
+        try:
+            if default_key == best_match:
+                max_sc = max((sc for (_, sc, _, _) in (locals().get('scored_table') or [])), default=0)
+                if max_sc <= 0:
+                    cat_label = f"{best_match} (default)"
+        except Exception:
+            pass
+        card.set_decision(f"{status_text.upper()}    root={target_root_folder}    category={cat_label}    profile={profile_id}")
 
     # File log: decision event with key fields
     try:

--- a/overfiltrr.py
+++ b/overfiltrr.py
@@ -5,8 +5,6 @@ import uuid
 import yaml
 import re
 import operator
-import logging
-import logging.config
 import argparse
 import hmac
 from datetime import datetime
@@ -20,16 +18,37 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from rapidfuzz import fuzz
 
+# Logging setup (optional, with graceful fallback)
+try:
+    from logging_setup import (
+        init_logging,
+        get_logger,
+        set_context,
+        new_request_card,
+        end_request_card,
+        get_current_card,
+    )
+except Exception:
+    def init_logging(cfg: dict):
+        pass
+    def get_logger(name: str = "overfiltrr"):
+        import logging
+        return logging.getLogger(name)
+    def set_context(**kwargs):
+        pass
+    def new_request_card(cfg: dict):
+        return None
+    def end_request_card():
+        pass
+    def get_current_card():
+        return None
+
 # =========================
 # App and global constants
 # =========================
 app = Flask(__name__)
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-LOG_DIRECTORY = os.path.join(SCRIPT_DIR, 'logs')
-os.makedirs(LOG_DIRECTORY, exist_ok=True)
-
-LOG_FILE = os.path.join(LOG_DIRECTORY, 'script.log')
 CONFIG_PATH = os.path.join(SCRIPT_DIR, 'config.yaml')
 
 TMDB_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500"
@@ -42,106 +61,6 @@ REQUIRED_KEYS = [
     'MOVIE_CATEGORIES'
 ]
 
-# =========================
-# Logging setup
-# =========================
-class Colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-
-class ColoredFormatter(logging.Formatter):
-    colon_pattern = re.compile(r'^(.*?):\s(.*)$')
-
-    def format(self, record):
-        base_message = super().format(record)
-        if getattr(record, 'is_console', False):
-            media_label = getattr(record, 'media_label', None)
-            media_value = getattr(record, 'media_value', None)
-            if media_label is not None and media_value is not None:
-                colored_label = f"{Colors.OKCYAN}{media_label}{Colors.ENDC}"
-                colored_value = f"{Colors.OKBLUE}{media_value}{Colors.ENDC}"
-                plain_substring = f"{media_label}: {media_value}"
-                colored_substring = f"{colored_label}: {colored_value}"
-                base_message = base_message.replace(plain_substring, colored_substring)
-
-            match = self.colon_pattern.match(base_message)
-            if match:
-                label_part = match.group(1)
-                value_part = match.group(2)
-                colored_label = f"{Colors.OKCYAN}{label_part}{Colors.ENDC}"
-                colored_value = f"{Colors.OKBLUE}{value_part}{Colors.ENDC}"
-                base_message = f"{colored_label}: {colored_value}"
-        return base_message
-
-class JsonFormatter(logging.Formatter):
-    def format(self, record: logging.LogRecord) -> str:
-        try:
-            payload = {
-                "ts": self.formatTime(record, self.datefmt),
-                "lvl": record.levelname,
-                "msg": record.getMessage(),
-                "rid": getattr(record, 'request_id', ''),
-                "cid": getattr(record, 'correlation_id', ''),
-            }
-            return json.dumps(payload, ensure_ascii=False)
-        except Exception:
-            return super().format(record)
-
-class ConsoleFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool:
-        record.is_console = True
-        return True
-
-class ContextDefaultsFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool:
-        if not hasattr(record, 'request_id'):
-            record.request_id = ''
-        if not hasattr(record, 'correlation_id'):
-            record.correlation_id = ''
-        return True
-
-LOGGING_CONFIG = {
-    'version': 1,
-    'disable_existing_loggers': False,
-
-    'formatters': {
-        'standard': {'format': '%(asctime)s - %(levelname)s - %(message)s'},
-        'colored':  {'()': f'{__name__}.ColoredFormatter',
-                     'format': '%(asctime)s - %(levelname)s - %(message)s'},
-        'json':     {'()': f'{__name__}.JsonFormatter'}
-    },
-
-    'filters': {
-        'console_filter': {'()': f'{__name__}.ConsoleFilter'},
-        'context_defaults': {'()': f'{__name__}.ContextDefaultsFilter'},
-    },
-
-    'handlers': {
-        'console': {
-            'level': 'DEBUG', 'class': 'logging.StreamHandler',
-            'formatter': 'colored',
-            'filters': ['console_filter', 'context_defaults']
-        },
-        'file': {
-            'level': 'DEBUG', 'class': 'logging.FileHandler',
-            'filename': LOG_FILE, 'formatter': 'json', 'encoding': 'utf-8',
-            'filters': ['context_defaults']
-        }
-    },
-
-    'root': {
-        'level': os.environ.get('LOG_LEVEL', 'INFO'),
-        'handlers': ['console', 'file']
-    }
-}
-
-def setup_logging():
-    logging.config.dictConfig(LOGGING_CONFIG)
 
 # =========================
 # Config loading and checks
@@ -151,19 +70,19 @@ def load_config(path: str) -> dict:
         with open(path, 'r', encoding='utf-8') as f:
             config = yaml.safe_load(f) or {}
     except FileNotFoundError:
-        logging.critical(f"Configuration file 'config.yaml' not found at {path}.")
+        print(f"Configuration file 'config.yaml' not found at {path}.", file=sys.stderr)
         sys.exit(1)
     except yaml.YAMLError as e:
-        logging.critical(f"Error parsing 'config.yaml': {e}")
+        print(f"Error parsing 'config.yaml': {e}", file=sys.stderr)
         sys.exit(1)
 
     missing = [k for k in REQUIRED_KEYS if k not in config]
     if missing:
-        logging.critical(f"Missing required configuration keys: {', '.join(missing)}")
+        print(f"Missing required configuration keys: {', '.join(missing)}", file=sys.stderr)
         sys.exit(1)
 
     if not isinstance(config.get('DRY_RUN'), bool):
-        logging.critical("DRY_RUN must be a boolean.")
+        print("DRY_RUN must be a boolean.", file=sys.stderr)
         sys.exit(1)
 
     return config
@@ -179,6 +98,9 @@ DRY_RUN: bool = True
 API_KEYS: Dict[str, Any] = {}
 TV_CATEGORIES: Dict[str, Any] = {}
 MOVIE_CATEGORIES: Dict[str, Any] = {}
+
+# Keep full runtime config for logging/console preferences
+RUNTIME_CFG: Dict[str, Any] = {}
 
 WEBHOOK_TOKEN: Optional[str] = None
 ENFORCE_WEBHOOK_TOKEN: bool = False
@@ -260,63 +182,51 @@ def validate_categories(categories: dict, media_type: str) -> bool:
     valid = True
     default_key = categories.get("default")
     if default_key is None:
-        logging.error(f"No default category specified for {media_type}.")
         valid = False
 
     for name, data in categories.items():
         if name == "default":
             continue
         if not isinstance(data, dict):
-            logging.error(f"Category '{name}' must be a mapping.")
             valid = False
             continue
 
         # Optional marker
         if 'is_anime' in data and not isinstance(data['is_anime'], bool):
-            logging.error(f"Category '{name}' has non-boolean is_anime.")
             valid = False
 
         apply = data.get("apply", {})
         if "root_folder" not in apply:
-            logging.error(f"Category '{name}' missing apply.root_folder.")
             valid = False
 
         id_key = "sonarr_id" if media_type == 'tv' else "radarr_id"
         if id_key not in apply or not isinstance(apply[id_key], int):
-            logging.error(f"Category '{name}' missing integer apply.{id_key}.")
             valid = False
 
         default_profile_id = apply.get("default_profile_id")
         if not isinstance(default_profile_id, int):
-            logging.error(f"Category '{name}' missing integer apply.default_profile_id.")
             valid = False
 
         if "weight" not in data or not isinstance(data["weight"], int):
-            logging.error(f"Category '{name}' missing integer weight.")
             valid = False
 
         filters = data.get("filters", {})
         if filters and not isinstance(filters, dict):
-            logging.error(f"Category '{name}' filters must be a mapping if present.")
             valid = False
 
         rat = data.get("ratings")
         if rat is not None:
             if not isinstance(rat, dict):
-                logging.error(f"Category '{name}' ratings must be a mapping.")
                 valid = False
             else:
                 ceiling = rat.get("ceiling")
                 prefer = rat.get("prefer")
                 if ceiling is not None and normalise_rating(str(ceiling)) is None:
-                    logging.error(f"Category '{name}' ratings.ceiling '{ceiling}' is not recognised.")
                     valid = False
                 if prefer is not None and normalise_rating(str(prefer)) is None:
-                    logging.error(f"Category '{name}' ratings.prefer '{prefer}' is not recognised.")
                     valid = False
 
     if default_key and default_key not in categories:
-        logging.error(f"Default key '{default_key}' not found in categories for {media_type}.")
         valid = False
     return valid
 
@@ -324,9 +234,7 @@ def validate_configuration():
     tv_ok = validate_categories(TV_CATEGORIES, 'tv')
     movie_ok = validate_categories(MOVIE_CATEGORIES, 'movie')
     if not (tv_ok and movie_ok):
-        logging.critical("Configuration validation failed.")
         sys.exit(1)
-    logging.info("Configuration loaded and validated successfully.")
 
 # =========================
 # Requests session client
@@ -416,23 +324,6 @@ def final_age_rating(overseerr_data: dict, media_type: str) -> Optional[str]:
     mapped = extract_all_certifications(overseerr_data, media_type)
     return pick_strictest(mapped)
 
-# =========================
-# Media extraction helpers
-# =========================
-def log_media_details(details: dict, header: str = "Media Details", request_id: str = "", correlation_id: str = ""):
-    logging.info("=" * 60, extra={'request_id': request_id, 'correlation_id': correlation_id})
-    logging.info(header, extra={'request_id': request_id, 'correlation_id': correlation_id})
-    logging.info("-" * 60, extra={'request_id': request_id, 'correlation_id': correlation_id})
-    for k, v in details.items():
-        if isinstance(v, list):
-            v = ', '.join(map(str, v))
-        if k == "Overview" and isinstance(v, str) and len(v) > 50:
-            v = v[:47] + "..."
-        logging.info("%s: %s", k, v,
-                     extra={'media_label': k, 'media_value': v,
-                            'request_id': request_id, 'correlation_id': correlation_id})
-    logging.info("=" * 60, extra={'request_id': request_id, 'correlation_id': correlation_id})
-
 def get_media_data(overseerr_data: dict, media_type: str, request_id: str, correlation_id: str):
     genres = [g.get('name', '') for g in overseerr_data.get('genres', [])]
 
@@ -448,8 +339,7 @@ def get_media_data(overseerr_data: dict, media_type: str, request_id: str, corre
         try:
             release_year = datetime.strptime(release_date_str, "%Y-%m-%d").year
         except ValueError:
-            logging.error(f"Invalid release date format: {release_date_str}",
-                          extra={'request_id': request_id, 'correlation_id': correlation_id})
+            pass
 
     providers: List[str] = []
     wp = overseerr_data.get('watchProviders', [])
@@ -489,8 +379,6 @@ def get_media_data(overseerr_data: dict, media_type: str, request_id: str, corre
         "Age Ratings Collected": collected_raw if collected_raw else "None",
         "Final Age Rating": age_rating if age_rating else "None"
     }
-    log_media_details(details, header="Fetched Media Details From Overseerr",
-                      request_id=str(request_id), correlation_id=correlation_id)
 
     return (genres, keywords, release_year, providers, production_companies, networks,
             original_language, status, overview, imdbId, posterPath, age_rating)
@@ -615,7 +503,7 @@ def categorise_media_scored(
     *,
     request_id: str,
     correlation_id: str
-) -> Tuple[Optional[str], Optional[str]]:
+) -> Tuple[Optional[str], Optional[str], List[Tuple[str, int, int, List[str]]]]:
     """
     Pick the category with the highest positive score.
     Tie-break by higher weight.
@@ -647,32 +535,17 @@ def categorise_media_scored(
             best_score = score
             best_weight = weight
 
-    try:
-        table = "; ".join(f"{n}: s={s}, w={w}" for (n, s, w, _r) in scored_table)
-        logging.info(f"Category scores → {table}",
-                     extra={'request_id': request_id, 'correlation_id': correlation_id})
-    except Exception:
-        pass
+    # scoring table prepared
 
     if best_cat:
         root_folder = categories[best_cat]["apply"]["root_folder"]
-        logging.info(
-            f"Category scored winner: {best_cat} (score={best_score}, weight={best_weight})",
-            extra={'request_id': request_id, 'correlation_id': correlation_id}
-        )
-        return root_folder, best_cat
+        return root_folder, best_cat, scored_table
 
     if default_key in categories:
         root_folder = categories[default_key]["apply"]["root_folder"]
-        logging.info(
-            f"No positive score. Falling back to default '{default_key}'.",
-            extra={'request_id': request_id, 'correlation_id': correlation_id}
-        )
-        return root_folder, default_key
+        return root_folder, default_key, scored_table
 
-    logging.error("No category matched and no default is defined.",
-                  extra={'request_id': request_id, 'correlation_id': correlation_id})
-    return None, None
+    return None, None, scored_table
 
 # =========================
 # Condition / operator engine
@@ -992,12 +865,9 @@ def evaluate_quality_profile_rules(rules: Optional[List[dict]], context: dict) -
             logic = 'OR'
         try:
             if evaluate_condition(condition, context, logic):
-                logging.info("Rule matched",
-                             extra={'media_label': 'Priority',
-                                    'media_value': rule.get('priority', 'N/A')})
                 return profile_id
         except Exception as e:
-            logging.error(f"Rule evaluation error: {e}")
+            pass
     return None
 
 # =========================
@@ -1009,12 +879,9 @@ def send_notifiarr_passthrough(payload: dict) -> None:
     try:
         url = f"https://notifiarr.com/api/v1/notification/passthrough/{NOTIFIARR_APIKEY}"
         r = session.post(url, json=payload, timeout=NOTIFIARR_TIMEOUT)
-        if r.status_code == 200:
-            logging.info("Notification sent via Notifiarr.")
-        else:
-            logging.error(f"Notifiarr passthrough failed {r.status_code}: {r.text}")
+        # silent on success/failure
     except Exception as e:
-        logging.error(f"Notifiarr passthrough exception: {e}")
+        pass
 
 # =========================
 # Discord payload builders
@@ -1049,7 +916,7 @@ def construct_movie_payload(media_title, request_username, status_text,
     if status_text != "Approved":
         payload["discord"]["text"]["fields"].append({
             "title": "NOT APPROVED",
-            "text": "This was not approved, check logs or settings.",
+            "text": "This was not approved, check settings.",
             "inline": False
         })
     if imdbId:
@@ -1090,7 +957,7 @@ def construct_tv_payload(media_title, request_username, status_text,
     if status_text != "Approved":
         payload["discord"]["text"]["fields"].append({
             "title": "NOT APPROVED",
-            "text": "This was not approved, check logs or settings.",
+            "text": "This was not approved, check settings.",
             "inline": False
         })
     if imdbId:
@@ -1110,6 +977,12 @@ def health():
 def handle_request():
     correlation_id = str(uuid.uuid4())
 
+    # Seed request context and prepare a console card
+    try:
+        set_context(correlation_id=correlation_id)
+    except Exception:
+        pass
+
     # Parse JSON once (accept even if content-type is off)
     request_data = request.get_json(force=True, silent=True)
 
@@ -1122,30 +995,58 @@ def handle_request():
                 provided = (hdrs.get('X-Webhook-Token') or hdrs.get('x-webhook-token') or '').strip()
 
         if not provided or not hmac.compare_digest(str(provided), str(WEBHOOK_TOKEN)):
-            logging.warning(
-                "Unauthorized webhook: missing or invalid token",
-                extra={'correlation_id': correlation_id}
-            )
             return ('Unauthorized', 401)
 
     if not isinstance(request_data, dict):
-        logging.error("Invalid JSON payload", extra={'correlation_id': correlation_id})
         return ('Bad Request', 400)
 
     notification_type = (request_data or {}).get('notification_type', '') or ''
     req = (request_data or {}).get('request', {}) or {}
     request_id = req.get('request_id') or ''
-    extra = {'request_id': str(request_id), 'correlation_id': correlation_id}
+    media = (request_data or {}).get('media', {}) or {}
+    media_type = media.get('media_type') or ''
+    tmdb_id = media.get('tmdbId') or ''
+    user = req.get('requestedBy_username') or ''
+    subject = (request_data or {}).get('subject') or ''
 
+    # Prepare a live card for this request (if configured)
+    try:
+        ccfg = ((RUNTIME_CFG.get('LOGGING') or {}).get('CONSOLE') or {}) if isinstance(RUNTIME_CFG, dict) else {}
+        card = new_request_card(ccfg)
+        if card:
+            card.set_meta(title=subject, media_type=media_type, correlation_id=correlation_id,
+                          request_id=str(request_id or ''), tmdb_id=str(tmdb_id or ''), user=user,
+                          dry_run=DRY_RUN)
+    except Exception:
+        card = None
     if notification_type == 'TEST_NOTIFICATION':
-        logging.info("Test payload received", extra=extra)
         return ('Test payload received', 200)
 
     if notification_type == 'MEDIA_PENDING':
-        process_request(request_data, correlation_id)
+        logger = get_logger("overfiltrr")
+        try:
+            if card:
+                with card.live():
+                    logger.info("request.start", extra={"event": "request.start"})
+                    process_request(request_data, correlation_id)
+                    logger.info("request.end", extra={"event": "request.end"})
+            else:
+                logger.info("request.start", extra={"event": "request.start"})
+                process_request(request_data, correlation_id)
+                logger.info("request.end", extra={"event": "request.end"})
+        except Exception:
+            try:
+                if card:
+                    card.set_status('failed')
+            except Exception:
+                pass
+        finally:
+            try:
+                end_request_card()
+            except Exception:
+                pass
         return ('accepted', 202)
 
-    logging.warning(f"Unhandled notification type: {notification_type}", extra=extra)
     return ('Unhandled notification type', 400)
 
 # =========================
@@ -1171,20 +1072,34 @@ def process_request(request_data: dict, correlation_id: str) -> None:
     media_type = media.get('media_type')
     media_title = request_data.get('subject', 'Unknown Title')
 
-    extra = {'request_id': str(request_id), 'correlation_id': correlation_id}
-
     if not all([request_id, media_tmdbid, media_type]):
-        logging.error("Payload missing request_id or tmdbId or media_type", extra=extra)
+        try:
+            set_context(request_id=request_id, tmdb_id=media_tmdbid, media_type=media_type, user=request_username)
+        except Exception:
+            pass
+        card = get_current_card()
+        if card:
+            card.set_status('aborted')
         return
 
-    logging.info(f"Processing: {media_title} ({media_type}) "
-                 f"req={request_id} user={request_username}", extra=extra)
-
     # Fetch media details
+    card = get_current_card()
+    logger = get_logger("overfiltrr")
     try:
-        overseerr_data = overseerr_client.get_media(media_type, media_tmdbid)
+        set_context(request_id=request_id, tmdb_id=media_tmdbid, media_type=media_type, user=request_username)
+    except Exception:
+        pass
+    try:
+        if card:
+            with card.step("Fetch media details") as s:
+                overseerr_data = overseerr_client.get_media(media_type, media_tmdbid)
+            logger.info("step", extra={"event": "step", "step": "Fetch media details", "ok": s.ok, "delta_ms": s.delta_ms, "cumulative_ms": s.cumulative_ms})
+        else:
+            overseerr_data = overseerr_client.get_media(media_type, media_tmdbid)
     except Exception as e:
-        logging.error(f"Failed to fetch media details: {e}", extra=extra)
+        if card:
+            card.set_status('failed')
+        logger.error("fetch_failed", extra={"event": "error", "exc_type": type(e).__name__, "exc_msg": str(e)})
         return
 
     (genres, keywords, release_year, providers, production_companies, networks,
@@ -1197,32 +1112,61 @@ def process_request(request_data: dict, correlation_id: str) -> None:
     best_match = None
 
     try:
-        if is_anime_hard(
-            genres=genres,
-            keywords=keywords,
-            original_language=original_language,
-            production_companies=production_companies,
-            networks=networks
-        ):
-            categories = MOVIE_CATEGORIES if media_type == 'movie' else TV_CATEGORIES
-            anime_cat = _pick_marked_anime_category(categories)
-            if anime_cat:
-                best_match = anime_cat
-                target_root_folder = categories[anime_cat]["apply"]["root_folder"]
-                logging.info("Anime gate matched → routing to %s", best_match, extra=extra)
+        if card:
+            with card.step("Determine anime/non-anime") as s:
+                if is_anime_hard(
+                    genres=genres,
+                    keywords=keywords,
+                    original_language=original_language,
+                    production_companies=production_companies,
+                    networks=networks
+                ):
+                    categories = MOVIE_CATEGORIES if media_type == 'movie' else TV_CATEGORIES
+                    anime_cat = _pick_marked_anime_category(categories)
+                    if anime_cat:
+                        best_match = anime_cat
+                        target_root_folder = categories[anime_cat]["apply"]["root_folder"]
+            logger.info("step", extra={"event": "step", "step": "Determine anime/non-anime", "ok": s.ok, "delta_ms": s.delta_ms, "cumulative_ms": s.cumulative_ms})
+        else:
+            if is_anime_hard(
+                genres=genres,
+                keywords=keywords,
+                original_language=original_language,
+                production_companies=production_companies,
+                networks=networks
+            ):
+                categories = MOVIE_CATEGORIES if media_type == 'movie' else TV_CATEGORIES
+                anime_cat = _pick_marked_anime_category(categories)
+                if anime_cat:
+                    best_match = anime_cat
+                    target_root_folder = categories[anime_cat]["apply"]["root_folder"]
     except Exception as e:
-        logging.error(f"Anime gate check failed: {e}", extra=extra)
+        logger.error("anime_gate_error", extra={"event": "error", "exc_type": type(e).__name__, "exc_msg": str(e)})
 
     # If no anime route, run the scorer
     if not target_root_folder or not best_match:
-        target_root_folder, best_match = categorise_media_scored(
-            genres, keywords, providers, networks, age_rating,
-            media_type,
-            request_id=str(request_id), correlation_id=correlation_id
-        )
+        if card:
+            with card.step("Score categories") as s:
+                target_root_folder, best_match, scored_table = categorise_media_scored(
+                    genres, keywords, providers, networks, age_rating,
+                    media_type,
+                    request_id=str(request_id), correlation_id=correlation_id
+                )
+                try:
+                    card.set_scoring(scored_table)
+                except Exception:
+                    pass
+            logger.info("step", extra={"event": "step", "step": "Score categories", "ok": s.ok, "delta_ms": s.delta_ms, "cumulative_ms": s.cumulative_ms})
+        else:
+            target_root_folder, best_match, scored_table = categorise_media_scored(
+                genres, keywords, providers, networks, age_rating,
+                media_type,
+                request_id=str(request_id), correlation_id=correlation_id
+            )
 
     if not target_root_folder or not best_match:
-        logging.error("No matching category found", extra=extra)
+        if card:
+            card.set_status('rejected')
         return
 
     categories = MOVIE_CATEGORIES if media_type == 'movie' else TV_CATEGORIES
@@ -1245,9 +1189,15 @@ def process_request(request_data: dict, correlation_id: str) -> None:
         'final_rating': age_rating,
     }
 
-    profile_id = evaluate_quality_profile_rules(quality_profile_rules, context) or default_profile_id
+    if card:
+        with card.step("Evaluate quality profile rules") as s:
+            profile_id = evaluate_quality_profile_rules(quality_profile_rules, context) or default_profile_id
+        logger.info("step", extra={"event": "step", "step": "Evaluate quality profile rules", "ok": s.ok, "delta_ms": s.delta_ms, "cumulative_ms": s.cumulative_ms})
+    else:
+        profile_id = evaluate_quality_profile_rules(quality_profile_rules, context) or default_profile_id
     if not isinstance(profile_id, int):
-        logging.error("Could not determine a valid profile id", extra=extra)
+        if card:
+            card.set_status('aborted')
         return
 
     put_data: Dict[str, Any] = {}
@@ -1256,7 +1206,8 @@ def process_request(request_data: dict, correlation_id: str) -> None:
     if media_type == 'movie':
         radarr_id = apply_data.get('radarr_id')
         if radarr_id is None:
-            logging.error(f"Category '{best_match}' missing radarr_id", extra=extra)
+            if card:
+                card.set_status('aborted')
             return
         put_data = {
             "mediaType": "movie",
@@ -1267,7 +1218,8 @@ def process_request(request_data: dict, correlation_id: str) -> None:
     elif media_type == 'tv':
         sonarr_id = apply_data.get('sonarr_id')
         if sonarr_id is None:
-            logging.error(f"Category '{best_match}' missing sonarr_id", extra=extra)
+            if card:
+                card.set_status('aborted')
             return
         # Seasons parsing
         seasons = []
@@ -1285,38 +1237,43 @@ def process_request(request_data: dict, correlation_id: str) -> None:
             "profileId": profile_id
         }
     else:
-        logging.error(f"Unsupported media_type '{media_type}'", extra=extra)
+        if card:
+            card.set_status('aborted')
         return
 
-    logging.info(
-        f"Decision: category={best_match} app={target_name} "
-        f"root='{put_data.get('rootFolder')}' profile={profile_id}",
-        extra=extra
-    )
+    # decision computed: category, target app, root, profile
 
     # Update request and (optionally) approve
     if DRY_RUN:
-        logging.warning("[DRY RUN] Would PUT request and %s",
-                        "approve" if ALLOW_AUTO_APPROVE else "not approve",
-                        extra=extra)
+        if card:
+            with card.step("Apply decision (dry-run)") as s:
+                _ = True
+            logger.info("step", extra={"event": "step", "step": "Apply decision (dry-run)", "ok": s.ok, "delta_ms": s.delta_ms, "cumulative_ms": s.cumulative_ms})
     else:
         try:
-            current_status = overseerr_client.get_request_status(request_id)
-            if current_status == 2:
-                logging.info(f"Request {request_id} already approved, updating only", extra=extra)
-
-            overseerr_client.put_request(request_id, put_data)
-
-            if ALLOW_AUTO_APPROVE:
-                if current_status != 2:
-                    overseerr_client.approve_request(request_id)
-                    logging.info(f"Request {request_id} approved", extra=extra)
-                else:
-                    logging.info(f"Request {request_id} remained approved", extra=extra)
+            if card:
+                with card.step("Update request") as s:
+                    current_status = overseerr_client.get_request_status(request_id)
+                    if current_status == 2:
+                        pass
+                    overseerr_client.put_request(request_id, put_data)
+                logger.info("step", extra={"event": "step", "step": "Update request", "ok": s.ok, "delta_ms": s.delta_ms, "cumulative_ms": s.cumulative_ms})
+                if ALLOW_AUTO_APPROVE:
+                    with card.step("Approve request") as s2:
+                        if current_status != 2:
+                            overseerr_client.approve_request(request_id)
+                    logger.info("step", extra={"event": "step", "step": "Approve request", "ok": s2.ok, "delta_ms": s2.delta_ms, "cumulative_ms": s2.cumulative_ms})
             else:
-                logging.info("Auto-approve disabled; request left pending", extra=extra)
+                current_status = overseerr_client.get_request_status(request_id)
+                if current_status == 2:
+                    pass
+                overseerr_client.put_request(request_id, put_data)
+                if ALLOW_AUTO_APPROVE and current_status != 2:
+                    overseerr_client.approve_request(request_id)
         except Exception as e:
-            logging.error(f"Failed to update or approve: {e}", extra=extra)
+            if card:
+                card.set_status('failed')
+            logger.error("update_failed", extra={"event": "error", "exc_type": type(e).__name__, "exc_msg": str(e)})
             return
 
     # Final status and notification
@@ -1348,9 +1305,20 @@ def process_request(request_data: dict, correlation_id: str) -> None:
                 posterPath=posterPath,
                 best_match=best_match
             )
-        send_notifiarr_passthrough(payload)
+        if card:
+            with card.step("Send notification") as s:
+                send_notifiarr_passthrough(payload)
+            logger.info("step", extra={"event": "step", "step": "Send notification", "ok": s.ok, "delta_ms": s.delta_ms, "cumulative_ms": s.cumulative_ms})
+        else:
+            send_notifiarr_passthrough(payload)
     else:
-        logging.debug("No Notifiarr API key present, skipping notification", extra=extra)
+        pass
+
+    # Final decision banner
+    card = get_current_card()
+    if card:
+        card.set_status('accepted')
+        card.set_decision(f"{status_text.upper()}    root={target_root_folder}    category={best_match}    profile={profile_id}")
 
 # =========================
 # Main
@@ -1364,6 +1332,13 @@ def init_runtime(cfg_path: str = CONFIG_PATH) -> dict:
     global overseerr_client
 
     cfg = load_config(cfg_path)
+    # Initialise logging early
+    try:
+        init_logging(cfg)
+    except Exception:
+        pass
+    global RUNTIME_CFG
+    RUNTIME_CFG = cfg
 
     OVERSEERR_BASEURL = str(cfg['OVERSEERR_BASEURL']).rstrip('/')
     DRY_RUN = bool(cfg['DRY_RUN'])
@@ -1399,7 +1374,6 @@ def init_runtime(cfg_path: str = CONFIG_PATH) -> dict:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    setup_logging()  # Ensure logs work for early failures/CLI
 
     parser = argparse.ArgumentParser(prog='overfiltrr', description='Overseerr request filter/categoriser')
     parser.add_argument('-c', '--config', default=CONFIG_PATH, help='Path to config.yaml')
@@ -1477,7 +1451,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     try:
         init_runtime(args.config)
         validate_configuration()
-        logging.info(f"Configuration valid. Starting server on {SERVER_HOST}:{SERVER_PORT}")
         serve(
             app,
             host=SERVER_HOST,
@@ -1490,7 +1463,6 @@ def main(argv: Optional[List[str]] = None) -> int:
     except SystemExit as e:
         return int(e.code or 1)
     except Exception:
-        logging.exception("Fatal error starting server")
         return 1
     return 0
 

--- a/overfiltrr.py
+++ b/overfiltrr.py
@@ -27,6 +27,7 @@ try:
         new_request_card,
         end_request_card,
         get_current_card,
+        render_startup_card,
     )
 except Exception:
     def init_logging(cfg: dict):
@@ -42,6 +43,8 @@ except Exception:
         pass
     def get_current_card():
         return None
+    def render_startup_card(**kwargs):
+        pass
 
 # =========================
 # App and global constants
@@ -1449,8 +1452,19 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     # default: serve
     try:
-        init_runtime(args.config)
-        validate_configuration()
+        cfg = init_runtime(args.config)
+        try:
+            validate_configuration()
+        except SystemExit as e:
+            try:
+                render_startup_card(cfg=cfg, host=SERVER_HOST, port=SERVER_PORT, threads=SERVER_THREADS, connection_limit=SERVER_CONNECTION_LIMIT, ok=False, message="Invalid configuration")
+            finally:
+                raise
+
+        try:
+            render_startup_card(cfg=cfg, host=SERVER_HOST, port=SERVER_PORT, threads=SERVER_THREADS, connection_limit=SERVER_CONNECTION_LIMIT, ok=True)
+        except Exception:
+            pass
         serve(
             app,
             host=SERVER_HOST,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ waitress==2.1.2
 requests==2.31.0
 PyYAML==6.0
 rapidfuzz==3.1.1
+rich==13.7.1
+python-json-logger==2.0.7


### PR DESCRIPTION
This PR implements request‑scoped, structured logging with a Rich‑styled console card and rotating NDJSON file logs.

**Highlights**

- Console (Rich card)
  - One card per webhook with badges (MOVIE/SERIES, DRY‑RUN, status) and correlation ID.
  - Live step updates (Fetch details, Anime gate, Scoring, Profile rules, Update/Approve, Notify) using `Live`.
  - Scoring table with a 10‑slot visual bar (scaled by max score), numeric score, weight, and compact reasons ("+k more").
  - Responsive layout: Wide (two columns: Steps | Scoring) and Narrow (stacked). ASCII fallback supported.
  - Final decision banner with status color.

- File logs (NDJSON)
  - Asynchronous writer via `QueueHandler` + `TimedRotatingFileHandler` (midnight rotation, keep 7).
  - Uses `python-json-logger` when present, otherwise a built‑in NDJSON formatter; prefers `orjson` when available.
  - Stable schema fields: `ts`, `level`, `event`, `message`, `logger`, `correlation_id`, `request_id`, `media_type`, `tmdb_id`, `user`, `step`, `ok`, `delta_ms`, `cumulative_ms`, `decision`, `category`, `root`, `profile_id`, `score_total`, `exc_type`, `exc_msg`.

- Integration
  - New module: `logging_setup.py` (init, contextvars, RequestCard renderer).
  - `overfiltrr.py`: `init_runtime()` calls `init_logging()`; `/webhook` starts a card and logs `request.start`/`request.end`; `process_request()` adds step timing, attaches the scoring table, and sets the final decision banner.
  - `requirements.txt`: add `rich` and `python-json-logger`.
  - `README`: Logging section with configuration snippet.

**Config**

```yaml
LOGGING:
  LEVEL: INFO
  CONSOLE:
    enabled: true
    ascii: false
  FILE:
    enabled: true
    path: logs/overfiltrr.log
    rotate:
      when: midnight
      backup_count: 7
```

**Notes**
- Graceful fallback when Rich/JSON deps are absent (plain console + built‑in NDJSON).
- Focused changes; core decision logic untouched.

**Future Improvements**
- High‑contrast theme toggle and precise dotted‑leader fitting using `Measurement`.
- Optional “final‑only” render mode for very short requests.
